### PR TITLE
Remove "debugger" future item from the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -162,10 +162,9 @@ Coming Soon
 This project is under heavy development, and we have a lot of cool things in
 the oven. In the mean-time, star the project to show your support!
 
-| Feature               | Description                                                                        | Status      |
-|-----------------------|------------------------------------------------------------------------------------|-------------|
-| Debugging             | Validate a JSON instance against a JSON Schema step by step, like LLDB and GDB     | Not started |
-| Upgrading/Downgrading | Convert a JSON Schema into a later or older dialect                                | Not started |
+| Feature               | Description                                         | Status      |
+|-----------------------|-----------------------------------------------------|-------------|
+| Upgrading/Downgrading | Convert a JSON Schema into a later or older dialect | Not started |
 
 License
 -------


### PR DESCRIPTION
We already accomplish something very close with `--trace`.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
