### PR TITLE
Fix crash when printing `pattern` errors on `propertyNames`

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -4,4 +4,4 @@ jsontoolkit https://github.com/sourcemeta/jsontoolkit 7a398224cc2e76ea9ae8541a87
 hydra https://github.com/sourcemeta/hydra a4a74f3cabd32f2f829f449d67339dac33f9910e
 alterschema https://github.com/sourcemeta/alterschema 92e370ce9c1f0582014b54d43e388ee012dfe13d
 jsonbinpack https://github.com/sourcemeta/jsonbinpack d777179441d3c703e1fda1187742541aa26836b5
-blaze https://github.com/sourcemeta/blaze 6b279890fe3f003e87eec55f7ced40e91c713050
+blaze https://github.com/sourcemeta/blaze 4990da88241847b561cf43efba2c0c7d2bfc9642

--- a/vendor/blaze/src/compiler/compile_describe.cc
+++ b/vendor/blaze/src/compiler/compile_describe.cc
@@ -1004,6 +1004,21 @@ struct DescribeVisitor {
   }
 
   auto operator()(const AssertionRegex &step) const -> std::string {
+    if (std::any_of(this->evaluate_path.cbegin(), this->evaluate_path.cend(),
+                    [](const auto &token) {
+                      return token.is_property() &&
+                             token.to_property() == "propertyNames";
+                    }) &&
+        !this->instance_location.empty() &&
+        this->instance_location.back().is_property()) {
+      std::ostringstream message;
+      message << "The property name "
+              << escape_string(this->instance_location.back().to_property())
+              << " was expected to match the regular expression "
+              << escape_string(step_value(step).second);
+      return message.str();
+    }
+
     assert(this->target.is_string());
     std::ostringstream message;
     message << "The string value " << escape_string(this->target.to_string())


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
