### PR TITLE
Make `metaschema` report exit code 2 on schema validation failure

### DIFF
--- a/docs/metaschema.markdown
+++ b/docs/metaschema.markdown
@@ -13,6 +13,9 @@ jsonschema metaschema [schemas-or-directories...]
 Ensure that a schema or a set of schemas are considered valid with regards to
 their metaschemas.
 
+To help scripts distinguish validation errors, these are reported using exit
+code 2.
+
 Examples
 --------
 

--- a/src/command_metaschema.cc
+++ b/src/command_metaschema.cc
@@ -68,5 +68,8 @@ auto sourcemeta::jsonschema::cli::metaschema(
     }
   }
 
-  return result ? EXIT_SUCCESS : EXIT_FAILURE;
+  return result ? EXIT_SUCCESS
+                // Report a different exit code for validation failures, to
+                // distinguish them from other errors
+                : 2;
 }

--- a/test/metaschema/fail_directory.sh
+++ b/test/metaschema/fail_directory.sh
@@ -24,7 +24,7 @@ cat << 'EOF' > "$TMP/schemas/schema_2.json"
 EOF
 
 "$1" metaschema "$TMP/schemas" 2>"$TMP/stderr.txt" && CODE="$?" || CODE="$?"
-test "$CODE" = "1" || exit 1
+test "$CODE" = "2" || exit 1
 
 cat << EOF > "$TMP/expected.txt"
 fail: $(realpath "$TMP")/schemas/schema_2.json

--- a/test/metaschema/fail_single.sh
+++ b/test/metaschema/fail_single.sh
@@ -15,7 +15,7 @@ cat << 'EOF' > "$TMP/schema.json"
 EOF
 
 "$1" metaschema "$TMP/schema.json" 2>"$TMP/stderr.txt" && CODE="$?" || CODE="$?"
-test "$CODE" = "1" || exit 1
+test "$CODE" = "2" || exit 1
 
 cat << EOF > "$TMP/expected.txt"
 fail: $(realpath "$TMP")/schema.json

--- a/test/metaschema/fail_trace.sh
+++ b/test/metaschema/fail_trace.sh
@@ -16,7 +16,7 @@ EOF
 
 "$1" metaschema "$TMP/schema.json" --trace > "$TMP/output.txt" \
   && CODE="$?" || CODE="$?"
-test "$CODE" = "1" || exit 1
+test "$CODE" = "2" || exit 1
 
 # Order of execution can vary
 

--- a/test/metaschema/fail_yaml.sh
+++ b/test/metaschema/fail_yaml.sh
@@ -13,7 +13,7 @@ type: 1
 EOF
 
 "$1" metaschema "$TMP/schema.yaml" 2>"$TMP/stderr.txt" && CODE="$?" || CODE="$?"
-test "$CODE" = "1" || exit 1
+test "$CODE" = "2" || exit 1
 
 cat << EOF > "$TMP/expected.txt"
 fail: $(realpath "$TMP")/schema.yaml


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
