### PR TITLE
fix(cli): ensure unknown commands other than help return exit code 1

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -25,7 +25,7 @@ Commands:
             [--benchmark/-b] [--extension/-e <extension>]
             [--ignore/-i <schemas-or-directories>] [--trace/-t]
 
-       Validate one of more instances against the given schema.
+       Validate one or more instances against the given schema.
 
    metaschema [schemas-or-directories...] [--http/-h]
               [--extension/-e <extension>]
@@ -73,7 +73,8 @@ Commands:
 For more documentation, visit https://github.com/sourcemeta/jsonschema
 )EOF"};
 
-auto jsonschema_main(const std::string &program, const std::string &command,
+auto jsonschema_main([[maybe_unused]] const std::string &program,
+                     const std::string &command,
                      const std::span<const std::string> &arguments) -> int {
   if (command == "fmt") {
     return sourcemeta::jsonschema::cli::fmt(arguments);
@@ -93,13 +94,17 @@ auto jsonschema_main(const std::string &program, const std::string &command,
     return sourcemeta::jsonschema::cli::encode(arguments);
   } else if (command == "decode") {
     return sourcemeta::jsonschema::cli::decode(arguments);
-  } else {
+  } else if (command == "help") {
     std::cout << "JSON Schema CLI - v"
               << sourcemeta::jsonschema::cli::PROJECT_VERSION << "\n";
     std::cout << "Usage: " << std::filesystem::path{program}.filename().string()
               << " <command> [arguments...]\n";
     std::cout << USAGE_DETAILS;
     return EXIT_SUCCESS;
+  } else {
+    std::cerr << "error: Unknown command '" << command << "'.\n";
+    std::cerr << "Use '--help' for usage information.\n";
+    return EXIT_FAILURE;
   }
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -101,8 +101,8 @@ auto jsonschema_main(const std::string &program, const std::string &command,
     std::cout << USAGE_DETAILS;
     return EXIT_SUCCESS;
   } else {
-    std::cerr << "error: Unknown command '" << command << "'.\n";
-    std::cerr << "Use '--help' for usage information.\n";
+    std::cerr << "error: Unknown command '" << command << "'\n";
+    std::cerr << "Use '--help' for usage information\n";
     return EXIT_FAILURE;
   }
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -73,8 +73,7 @@ Commands:
 For more documentation, visit https://github.com/sourcemeta/jsonschema
 )EOF"};
 
-auto jsonschema_main([[maybe_unused]] const std::string &program,
-                     const std::string &command,
+auto jsonschema_main(const std::string &program, const std::string &command,
                      const std::span<const std::string> &arguments) -> int {
   if (command == "fmt") {
     return sourcemeta::jsonschema::cli::fmt(arguments);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ macro(add_jsonschema_test_unix_ci name)
 endmacro()
 
 add_jsonschema_test_unix(help)
+add_jsonschema_test_unix(unknown_command)
 add_jsonschema_test_unix(format_single)
 add_jsonschema_test_unix(format_invalid_path)
 add_jsonschema_test_unix(format_directory)

--- a/test/unknown_command.sh
+++ b/test/unknown_command.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 set -o errexit
 set -o nounset
 
@@ -7,21 +6,28 @@ TMP="$(mktemp -d)"
 clean() { rm -rf "$TMP"; }
 trap clean EXIT
 
-"$1" unknown_command 1> "$TMP/stdout" 2> "$TMP/stderr" || exit_code=$?
-
-if [ -z "${exit_code:-}" ] || [ "$exit_code" -eq 0 ]; then
+"$1" unknown_command 1> "$TMP/stdout" 2> "$TMP/stderr" && CODE="$?" || CODE="$?"
+if [ "$CODE" != "1" ]
+then
   echo "FAIL: Unknown command did not return exit code 1" 1>&2
   exit 1
 fi
-
-if [ -s "$TMP/stdout" ]; then
+if [ -s "$TMP/stdout" ]
+then
   echo "FAIL: Unexpected output to stdout for unknown command" 1>&2
   exit 1
 fi
-
-if ! [ -s "$TMP/stderr" ]; then
+if ! [ -s "$TMP/stderr" ]
+then
   echo "FAIL: No error message produced to stderr for unknown command" 1>&2
   exit 1
 fi
+
+cat << EOF > "$TMP/expected.txt"
+error: Unknown command 'unknown_command'
+Use '--help' for usage information
+EOF
+
+diff "$TMP/stderr" "$TMP/expected.txt"
 
 echo "PASS" 1>&2

--- a/test/unknown_command.sh
+++ b/test/unknown_command.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+TMP="$(mktemp -d)"
+clean() { rm -rf "$TMP"; }
+trap clean EXIT
+
+"$1" unknown_command 1> "$TMP/stdout" 2> "$TMP/stderr" || exit_code=$?
+
+if [ -z "${exit_code:-}" ] || [ "$exit_code" -eq 0 ]; then
+  echo "FAIL: Unknown command did not return exit code 1" 1>&2
+  exit 1
+fi
+
+if [ -s "$TMP/stdout" ]; then
+  echo "FAIL: Unexpected output to stdout for unknown command" 1>&2
+  exit 1
+fi
+
+if ! [ -s "$TMP/stderr" ]; then
+  echo "FAIL: No error message produced to stderr for unknown command" 1>&2
+  exit 1
+fi
+
+echo "PASS" 1>&2


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Fix: Make unknown commands other than "help" return exit code 1

**Issue Number:**

-  Closes #138 

**Screenshots/videos:**

![image](https://github.com/user-attachments/assets/24f2f86c-608b-42ae-a793-d9325109a5f3)

