### PR TITLE
fix: install in a different location for github actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,11 @@ runs:
     - name: Install the JSON Schema CLI (latest)
       shell: bash
       run: |
+        INSTALL_DIR="$HOME/.local/bin"
         curl --retry 5 --location --fail-early --silent --show-error \
           --output "${GITHUB_WORKSPACE}/install.sh" \
           "https://raw.githubusercontent.com/sourcemeta/jsonschema/main/install"
         chmod +x "${GITHUB_WORKSPACE}/install.sh"
-        "${GITHUB_WORKSPACE}/install.sh" 7.0.0
+        "${GITHUB_WORKSPACE}/install.sh" 7.0.0 "${INSTALL_DIR}"
         rm "${GITHUB_WORKSPACE}/install.sh"
+        echo "${INSTALL_DIR}" >> "$GITHUB_PATH"


### PR DESCRIPTION
Something has changed in the /usr/local/bin permission

However, GitHub actions can modify on the fly the PATH using the GITHUB_PATH env variable as explained in https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path


Part of https://github.com/sourcemeta/jsonschema/issues/249