### PR TITLE
Action fix: install dir should not contain `/bin`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,11 +6,11 @@ runs:
     - name: Install the JSON Schema CLI (latest)
       shell: bash
       run: |
-        INSTALL_DIR="$HOME/.local/bin"
+        INSTALL_DIR="$HOME/.local"
         curl --retry 5 --location --fail-early --silent --show-error \
           --output "${GITHUB_WORKSPACE}/install.sh" \
           "https://raw.githubusercontent.com/sourcemeta/jsonschema/main/install"
         chmod +x "${GITHUB_WORKSPACE}/install.sh"
         "${GITHUB_WORKSPACE}/install.sh" 7.0.1 "${INSTALL_DIR}"
         rm "${GITHUB_WORKSPACE}/install.sh"
-        echo "${INSTALL_DIR}" >> "$GITHUB_PATH"
+        echo "${INSTALL_DIR}/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
This is a followup to #250.  The install script seems to want the install root
and adds `/bin` to the install dir.  This means that the action installs the
binary to `${HOME}/.local/bin/bin` but adds `${HOME}/.local/bin` to the path,
which at least in my workflow is not enough to pick up the installed binary!