### PR TITLE
Remove Docker warning during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm as builder
+FROM debian:bookworm AS builder
 RUN apt-get --yes update && apt-get install --yes --no-install-recommends \
   build-essential cmake && apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Remove warning during build:
```
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1) 
```