### PR TITLE
Support `pre-commit` with the `lint` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Install ClangFormat
         run: pipx install clang-format==19.1.0
+      - name: Install pre-commit
+        run: pipx install pre-commit
 
       - uses: actions/checkout@v4
       - name: Install dependencies (macOS)

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,31 @@
+- id: sourcemeta-jsonschema-fmt
+  name: sourcemeta-jsonschema-fmt
+  description: Format JSON or YAML schema files
+  entry: jsonschema fmt
+  language: system
+  types_or: [json, yaml]
+  minimum_pre_commit_version: 2.9.0
+
+- id: sourcemeta-jsonschema-lint
+  name: sourcemeta-jsonschema-lint
+  description: Lint JSON or YAML schema files
+  entry: jsonschema lint
+  language: system
+  types_or: [json, yaml]
+  minimum_pre_commit_version: 2.9.0
+
+- id: sourcemeta-jsonschema-metaschema
+  name: sourcemeta-jsonschema-metaschema
+  description: Validate that a JSON or YAML schema or a set of schemas are valid with their metaschema
+  entry: jsonschema metaschema
+  language: system
+  types_or: [json, yaml]
+  minimum_pre_commit_version: 2.9.0
+
+- id: sourcemeta-jsonschema-validate
+  name: sourcemeta-jsonschema-validate
+  description: Validate JSON or YAML files against a JSON or YAML schema
+  entry: jsonschema validate
+  language: system
+  types_or: [json, yaml]
+  minimum_pre_commit_version: 2.9.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: sourcemeta-jsonschema-lint
   name: sourcemeta-jsonschema-lint
-  description: Lint JSON or YAML schema files
+  description: Lint schema files
   entry: jsonschema lint
   language: system
-  types_or: [json, yaml]
+  types_or: [ json, yaml ]
   minimum_pre_commit_version: 2.9.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,31 +1,7 @@
-- id: sourcemeta-jsonschema-fmt
-  name: sourcemeta-jsonschema-fmt
-  description: Format JSON or YAML schema files
-  entry: jsonschema fmt
-  language: system
-  types_or: [json, yaml]
-  minimum_pre_commit_version: 2.9.0
-
 - id: sourcemeta-jsonschema-lint
   name: sourcemeta-jsonschema-lint
   description: Lint JSON or YAML schema files
   entry: jsonschema lint
-  language: system
-  types_or: [json, yaml]
-  minimum_pre_commit_version: 2.9.0
-
-- id: sourcemeta-jsonschema-metaschema
-  name: sourcemeta-jsonschema-metaschema
-  description: Validate that a JSON or YAML schema or a set of schemas are valid with their metaschema
-  entry: jsonschema metaschema
-  language: system
-  types_or: [json, yaml]
-  minimum_pre_commit_version: 2.9.0
-
-- id: sourcemeta-jsonschema-validate
-  name: sourcemeta-jsonschema-validate
-  description: Validate JSON or YAML files against a JSON or YAML schema
-  entry: jsonschema validate
   language: system
   types_or: [json, yaml]
   minimum_pre_commit_version: 2.9.0

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ add_jsonschema_test_unix(format_check_single_pass)
 add_jsonschema_test_unix(format_directory_ignore_directory)
 add_jsonschema_test_unix(format_directory_ignore_file)
 add_jsonschema_test_unix(format_check_single_invalid)
+add_jsonschema_test_unix(precommit_lint)
 
 # Validate
 add_jsonschema_test_unix(validate/fail_instance_directory)

--- a/test/precommit_lint.sh
+++ b/test/precommit_lint.sh
@@ -25,7 +25,10 @@ cat << 'EOF' > "$TMP/schema.json"
 }
 EOF
 
+git -C "$TMP" add .
+
 cd "$TMP"
 pre-commit install
-pre-commit run --all-files && CODE="$?" || CODE="$?"
+pre-commit run --files schema.json > "$TMP/out.txt" && CODE="$?" || CODE="$?"
 test "$CODE" = "1" || exit 1
+grep -q "enum_with_type" "$TMP/out.txt" || (echo "$TMP/out.txt" && exit 1)

--- a/test/precommit_lint.sh
+++ b/test/precommit_lint.sh
@@ -29,6 +29,7 @@ git -C "$TMP" add .
 
 cd "$TMP"
 pre-commit install
-pre-commit run --files schema.json > "$TMP/out.txt" && CODE="$?" || CODE="$?"
+pre-commit run --files schema.json > "$TMP/out.txt" 2>&1 && CODE="$?" || CODE="$?"
+cat "$TMP/out.txt"
 test "$CODE" = "1" || exit 1
-grep -q "enum_with_type" "$TMP/out.txt" || (echo "$TMP/out.txt" && exit 1)
+grep -q "enum_with_type" "$TMP/out.txt" || exit 1

--- a/test/precommit_lint.sh
+++ b/test/precommit_lint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+TMP="$(mktemp -d)"
+clean() { rm -rf "$TMP"; }
+trap clean EXIT
+
+git -C "$TMP" init
+
+cat << EOF > "$TMP/.pre-commit-config.yaml"
+repos:
+- repo: $(dirname "$(dirname "$(pwd)")")
+  rev: HEAD
+  hooks:
+  - id: sourcemeta-jsonschema-lint
+EOF
+
+cat << 'EOF' > "$TMP/schema.json"
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "string",
+  "enum": [ "foo" ]
+}
+EOF
+
+cd "$TMP"
+pre-commit install
+pre-commit run --all-files && CODE="$?" || CODE="$?"
+test "$CODE" = "1" || exit 1


### PR DESCRIPTION
I only tested the `jsonschema lint` command

Might be a lot more to consider here but at least this gets the conversation started.

For instance: 

* some projects choose to have separate repos to support pre-commit: https://github.com/astral-sh/ruff-pre-commit
* there are other ways to deploy hook besides `system` https://pre-commit.com/index.html#node