### PR TITLE
Fix incorrect validation when setting `min(Length|Items|Properties)` to 0

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -2,4 +2,4 @@ vendorpull https://github.com/sourcemeta/vendorpull dea311b5bfb53b6926a414026795
 core https://github.com/sourcemeta/core 639d617d927709d8a58a7c88fa2aaeee5ded0f7f
 hydra https://github.com/sourcemeta/hydra a67b879df800e834ed8a2d056f98398f7211d870
 jsonbinpack https://github.com/sourcemeta/jsonbinpack c7bb7f4d903c3b6925b62ce2bb5b8d360e01ce84
-blaze https://github.com/sourcemeta/blaze a453075f2013ea8fc27d0dded1da6521dbc8474e
+blaze https://github.com/sourcemeta/blaze 7aab1200ff5d224aa2167807279ae168529adf89

--- a/vendor/blaze/src/compiler/compile_describe.cc
+++ b/vendor/blaze/src/compiler/compile_describe.cc
@@ -1323,7 +1323,7 @@ auto describe(const bool valid, const Instruction &step,
       std::ostringstream message;
       const auto maximum{instruction_value<ValueUnsignedInteger>(step) - 1};
       message << "The array value was expected to contain at most " << maximum;
-      assert(maximum > 0);
+      assert(maximum >= 0);
       if (maximum == 1) {
         message << " item";
       } else {
@@ -1355,7 +1355,7 @@ auto describe(const bool valid, const Instruction &step,
     std::ostringstream message;
     const auto minimum{instruction_value<ValueUnsignedInteger>(step) + 1};
     message << "The array value was expected to contain at least " << minimum;
-    assert(minimum > 0);
+    assert(minimum >= 0);
     if (minimum == 1) {
       message << " item";
     } else {
@@ -1390,7 +1390,7 @@ auto describe(const bool valid, const Instruction &step,
       std::ostringstream message;
       const auto maximum{instruction_value<ValueUnsignedInteger>(step) - 1};
       message << "The object value was expected to contain at most " << maximum;
-      assert(maximum > 0);
+      assert(maximum >= 0);
       if (maximum == 1) {
         message << " property";
       } else {
@@ -1404,7 +1404,9 @@ auto describe(const bool valid, const Instruction &step,
       }
 
       message << " it contained " << target.size();
-      if (target.size() == 1) {
+      if (target.size() == 0) {
+        message << " properties";
+      } else if (target.size() == 1) {
         message << " property: ";
         message << escape_string(target.as_object().cbegin()->first);
       } else {
@@ -1440,7 +1442,7 @@ auto describe(const bool valid, const Instruction &step,
       const auto minimum{instruction_value<ValueUnsignedInteger>(step) + 1};
       message << "The object value was expected to contain at least "
               << minimum;
-      assert(minimum > 0);
+      assert(minimum >= 0);
       if (minimum == 1) {
         message << " property";
       } else {

--- a/vendor/blaze/src/compiler/default_compiler_draft4.h
+++ b/vendor/blaze/src/compiler/default_compiler_draft4.h
@@ -2006,13 +2006,15 @@ auto compiler_draft4_validation_minlength(const Context &context,
     return {};
   }
 
-  return {make(
-      sourcemeta::blaze::InstructionIndex::AssertionStringSizeGreater, context,
-      schema_context, dynamic_context,
-      ValueUnsignedInteger{
-          static_cast<unsigned long>(
-              schema_context.schema.at(dynamic_context.keyword).as_integer()) -
-          1})};
+  const auto value{static_cast<unsigned long>(
+      schema_context.schema.at(dynamic_context.keyword).as_integer())};
+  if (value <= 0) {
+    return {};
+  }
+
+  return {make(sourcemeta::blaze::InstructionIndex::AssertionStringSizeGreater,
+               context, schema_context, dynamic_context,
+               ValueUnsignedInteger{value - 1})};
 }
 
 auto compiler_draft4_validation_maxitems(const Context &context,
@@ -2068,13 +2070,15 @@ auto compiler_draft4_validation_minitems(const Context &context,
     return {};
   }
 
-  return {make(
-      sourcemeta::blaze::InstructionIndex::AssertionArraySizeGreater, context,
-      schema_context, dynamic_context,
-      ValueUnsignedInteger{
-          static_cast<unsigned long>(
-              schema_context.schema.at(dynamic_context.keyword).as_integer()) -
-          1})};
+  const auto value{
+      schema_context.schema.at(dynamic_context.keyword).as_integer()};
+  if (value <= 0) {
+    return {};
+  }
+
+  return {make(sourcemeta::blaze::InstructionIndex::AssertionArraySizeGreater,
+               context, schema_context, dynamic_context,
+               ValueUnsignedInteger{static_cast<unsigned long>(value - 1)})};
 }
 
 auto compiler_draft4_validation_maxproperties(
@@ -2130,13 +2134,15 @@ auto compiler_draft4_validation_minproperties(
     return {};
   }
 
-  return {make(
-      sourcemeta::blaze::InstructionIndex::AssertionObjectSizeGreater, context,
-      schema_context, dynamic_context,
-      ValueUnsignedInteger{
-          static_cast<unsigned long>(
-              schema_context.schema.at(dynamic_context.keyword).as_integer()) -
-          1})};
+  const auto value{static_cast<unsigned long>(
+      schema_context.schema.at(dynamic_context.keyword).as_integer())};
+  if (value <= 0) {
+    return {};
+  }
+
+  return {make(sourcemeta::blaze::InstructionIndex::AssertionObjectSizeGreater,
+               context, schema_context, dynamic_context,
+               ValueUnsignedInteger{value - 1})};
 }
 
 auto compiler_draft4_validation_maximum(const Context &context,


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/jsonschema/issues/277
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
