### PR TITLE
Warn that `--without-id` technically results in invalid schemas

### DIFF
--- a/docs/bundle.markdown
+++ b/docs/bundle.markdown
@@ -29,6 +29,16 @@ this functionality through the `bundle` command.
 > identifiers to make your resulting schemas compatible with Visual Studio
 > Code.
 
+> [!CAUTION]
+> The `--without-id`/`-w` option may result in schemas that are not strictly
+> compliant with the JSON Schema specification. More specifically, it may
+> result in standalone instances of the `$schema` keyword that are [not
+> permitted outside the root of a schema
+> resource](https://json-schema.org/draft/2020-12/json-schema-core#section-8.1.1-4).
+> Therefore, only make use of this option to serve non-compliant
+> implementations like Visual Studio Code, and avoid using the resulting schema
+> in any other way.
+
 Examples
 --------
 


### PR DESCRIPTION
I don't think this can be fixed in any realistic way. The whole point of
this option is to workaround non-compliant implementations, so we are
already in non-compliant land. It should be OK as long as people don't
use these schemas for anything else.

If Visual Studio Code fixes their implementation, I would completely
remove this feature.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
