### PR TITLE
More prominently warn at runtime against using `--without-id` when bundling

### DIFF
--- a/src/command_bundle.cc
+++ b/src/command_bundle.cc
@@ -20,21 +20,28 @@ auto sourcemeta::jsonschema::cli::bundle(
     return EXIT_FAILURE;
   }
 
+  const auto custom_resolver{resolver(
+      options, options.contains("h") || options.contains("http"), dialect)};
   auto schema{sourcemeta::jsonschema::cli::read_file(options.at("").front())};
 
-  sourcemeta::core::bundle(
-      schema, sourcemeta::core::schema_official_walker,
-      resolver(options, options.contains("h") || options.contains("http"),
-               dialect),
-      dialect);
+  sourcemeta::core::bundle(schema, sourcemeta::core::schema_official_walker,
+                           custom_resolver, dialect);
 
   if (options.contains("w") || options.contains("without-id")) {
-    log_verbose(options) << "Removing schema identifiers\n";
-    sourcemeta::core::unidentify(
-        schema, sourcemeta::core::schema_official_walker,
-        resolver(options, options.contains("h") || options.contains("http"),
-                 dialect),
-        dialect);
+    std::cerr << "warning: You are opting in to remove schema identifiers in "
+                 "the bundled schema.\n";
+    std::cerr << "The only legit use case of this advanced feature we know of "
+                 "it to workaround\n";
+    std::cerr << "non-compliant JSON Schema implementations such as Visual "
+                 "Studio Code.\n";
+    std::cerr << "In other case, this is not needed and may harm other use "
+                 "cases. For example,\n";
+    std::cerr << "you will be unable to reference the resulting schema from "
+                 "other schemas\n";
+    std::cerr << "using the --resolve/-r option.\n";
+    sourcemeta::core::unidentify(schema,
+                                 sourcemeta::core::schema_official_walker,
+                                 custom_resolver, dialect);
   }
 
   sourcemeta::core::prettify(schema, std::cout,

--- a/test/bundle/pass_without_id.sh
+++ b/test/bundle/pass_without_id.sh
@@ -24,7 +24,7 @@ cat << 'EOF' > "$TMP/schemas/remote.json"
 }
 EOF
 
-"$1" bundle "$TMP/schema.json" --resolve "$TMP/schemas" --without-id > "$TMP/result.json"
+"$1" bundle "$TMP/schema.json" --resolve "$TMP/schemas" --without-id > "$TMP/result.json" 2> "$TMP/stderr.txt"
 
 cat << 'EOF' > "$TMP/expected.json"
 {
@@ -39,7 +39,17 @@ cat << 'EOF' > "$TMP/expected.json"
 }
 EOF
 
+cat << 'EOF' > "$TMP/expected-stderr.txt"
+warning: You are opting in to remove schema identifiers in the bundled schema.
+The only legit use case of this advanced feature we know of it to workaround
+non-compliant JSON Schema implementations such as Visual Studio Code.
+In other case, this is not needed and may harm other use cases. For example,
+you will be unable to reference the resulting schema from other schemas
+using the --resolve/-r option.
+EOF
+
 diff "$TMP/result.json" "$TMP/expected.json"
+diff "$TMP/stderr.txt" "$TMP/expected-stderr.txt"
 
 # Must come out formatted
 "$1" fmt "$TMP/result.json" --check

--- a/test/bundle/pass_without_id_verbose.sh
+++ b/test/bundle/pass_without_id_verbose.sh
@@ -28,8 +28,12 @@ EOF
 
 cat << EOF > "$TMP/expected.json"
 Importing schema into the resolution context: $(realpath "$TMP")/schemas/remote.json
-Removing schema identifiers
-Importing schema into the resolution context: $(realpath "$TMP")/schemas/remote.json
+warning: You are opting in to remove schema identifiers in the bundled schema.
+The only legit use case of this advanced feature we know of it to workaround
+non-compliant JSON Schema implementations such as Visual Studio Code.
+In other case, this is not needed and may harm other use cases. For example,
+you will be unable to reference the resulting schema from other schemas
+using the --resolve/-r option.
 {
   "\$schema": "https://json-schema.org/draft/2020-12/schema",
   "\$ref": "#/\$defs/https%3A~1~1example.com~1nested",
@@ -41,7 +45,5 @@ Importing schema into the resolution context: $(realpath "$TMP")/schemas/remote.
   }
 }
 EOF
-
-cat "$TMP/result.json"
 
 diff "$TMP/result.json" "$TMP/expected.json"


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
