### PR TITLE
Fix `lint` crashes when validating examples and default values

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -2,4 +2,4 @@ vendorpull https://github.com/sourcemeta/vendorpull dea311b5bfb53b6926a414026795
 core https://github.com/sourcemeta/core d15c45c2dabb7418584dc5f23b22301e30ae4172
 hydra https://github.com/sourcemeta/hydra a67b879df800e834ed8a2d056f98398f7211d870
 jsonbinpack https://github.com/sourcemeta/jsonbinpack 7028964423b96755c4ea6869aa7bc439650ceecd
-blaze https://github.com/sourcemeta/blaze 423950ff12190a50c46463e69a4b16eaeb36fe7b
+blaze https://github.com/sourcemeta/blaze b28f3bd9e5b607ad8f8200396a453785308bda4c

--- a/vendor/blaze/src/linter/valid_default.cc
+++ b/vendor/blaze/src/linter/valid_default.cc
@@ -28,7 +28,7 @@ auto ValidDefault::condition(
     return false;
   }
 
-  if (!schema.defines("default")) {
+  if (!schema.is_object() || !schema.defines("default")) {
     return false;
   }
 

--- a/vendor/blaze/src/linter/valid_examples.cc
+++ b/vendor/blaze/src/linter/valid_examples.cc
@@ -26,8 +26,8 @@ auto ValidExamples::condition(
     return false;
   }
 
-  if (!schema.defines("examples") || !schema.at("examples").is_array() ||
-      schema.at("examples").empty()) {
+  if (!schema.is_object() || !schema.defines("examples") ||
+      !schema.at("examples").is_array() || schema.at("examples").empty()) {
     return false;
   }
 


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/jsonschema/issues/323
Fixes: https://github.com/sourcemeta/jsonschema/issues/294
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
