### PR TITLE
ci: Remove extra prefix on files in CHECKSUMS.txt

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -122,7 +122,7 @@ jobs:
           merge-multiple: true
 
       # Generate checksums for all pre-built binaries
-      # avoid "build/out/" in the checksum file.
+      # while avoiding "build/out/" in the checksum file.
       - run: sha256sum --tag *.zip >CHECKSUMS.txt
         working-directory: build/out/
       - run: cat CHECKSUMS.txt


### PR DESCRIPTION
Fixes the path of files in the CHECKSUMS, so that the validation can be run directly.
```
SHA256(build/out/...) = ...
```

Reference: https://github.com/sourcemeta/jsonschema/issues/344
Signed-off-by: Robin H. Johnson <rjohnson@coreweave.com>