### PR TITLE
add loop option

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -34,14 +34,15 @@ Commands:
    validate <schema.json|.yaml> <instance.json|.jsonl|.yaml...> [--http/-h]
             [--benchmark/-b] [--extension/-e <extension>]
             [--ignore/-i <schemas-or-directories>] [--trace/-t] [--fast/-f]
-            [--template/-m <template.json>] [--json/-j]
+            [--template/-m <template.json>] [--json/-j] [--loop <iterations>]
 
        Validate one or more instances against the given schema.
 
        By default, schemas are validated in exhaustive mode, which results in
        better error messages, at the expense of speed. The --fast/-f option
        makes the schema compiler optimise for speed, at the expense of error
-       messages.
+       messages. Looping in benchmark mode allows to collect the execution time
+       average and standard deviation for the fast mode on basic JSON data.
 
        You may additionally pass a pre-compiled schema template (see the
        `compile` command). However, you still need to pass the original schema


### PR DESCRIPTION
A basic attempt at adding a loop option to report execution time average and standard deviation from a non C++ programmer. Example run:

```sh
time /usr/local/bin/jsonschema validate -b --loop 1000 ./openapi_31_20250213.schema.json example.json
```

Output:

```
took: 1127.994 +- 41.831 us (0.000)

real    0m54,955s
user    0m54,905s
sys     0m0,041s
```

So the compilation took about 53 seconds (which seems like a lot?), and running 1000 times over the sample (the benchmark/instance OpenAPI example with the missing "openapi" and "info" properties added) took about 1.1 seconds, so one check is really about 1.12 ms.