### PR TITLE
Fix `explicity` => `explicitly` typo when suggesting `--default-dialect`

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -162,7 +162,7 @@ auto main(int argc, char *argv[]) noexcept -> int {
     std::cerr << "If the input does not declare the $schema keyword, you might "
                  "want to\n";
     std::cerr
-        << "explicity declare a default dialect using --default-dialect/-d\n";
+        << "explicitly declare a default dialect using --default-dialect/-d\n";
     return EXIT_FAILURE;
   } catch (const sourcemeta::core::SchemaError &error) {
     std::cerr << "error: " << error.what() << "\n";

--- a/test/lint/fail_lint_non_schema.sh
+++ b/test/lint/fail_lint_non_schema.sh
@@ -19,7 +19,7 @@ error: Could not determine the base dialect of the schema
 
 Are you sure the input is a valid JSON Schema and its base dialect is known?
 If the input does not declare the \$schema keyword, you might want to
-explicity declare a default dialect using --default-dialect/-d
+explicitly declare a default dialect using --default-dialect/-d
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/test/fail_resolve_directory_non_schema.sh
+++ b/test/test/fail_resolve_directory_non_schema.sh
@@ -45,7 +45,7 @@ error: Could not determine the base dialect of the schema
 
 Are you sure the input is a valid JSON Schema and its base dialect is known?
 If the input does not declare the \$schema keyword, you might want to
-explicity declare a default dialect using --default-dialect/-d
+explicitly declare a default dialect using --default-dialect/-d
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/issues/350#issuecomment-2991787728
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
