### PR TITLE
Fix `lint` not processing nested `default`/`examples` when the schema has an identifier

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -2,4 +2,4 @@ vendorpull https://github.com/sourcemeta/vendorpull dea311b5bfb53b6926a414026795
 core https://github.com/sourcemeta/core 0839c199a2952fac12e89321cd6ad7d3934acc7e
 hydra https://github.com/sourcemeta/hydra 26aff4875f5587e0dbac7d148736ee65ebd6e672
 jsonbinpack https://github.com/sourcemeta/jsonbinpack 61a04d9d304343d8c206972225393f7ae0d5b603
-blaze https://github.com/sourcemeta/blaze ec936ca8d05c2feeacd0de35d5ed0b69922fa397
+blaze https://github.com/sourcemeta/blaze c28e4aa0eb366b0f4f49a10873a857ee382a282c

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -239,6 +239,8 @@ add_jsonschema_test_unix(lint/pass_lint_default_fix)
 add_jsonschema_test_unix(lint/pass_lint_default_no_fix)
 add_jsonschema_test_unix(lint/pass_lint_anonymous_default_with_ref)
 add_jsonschema_test_unix(lint/pass_lint_anonymous_nested_default_with_ref)
+add_jsonschema_test_unix(lint/pass_lint_default_nested_with_id)
+add_jsonschema_test_unix(lint/pass_lint_examples_nested_with_id)
 
 # Encode
 add_jsonschema_test_unix(encode/pass_schema_less)

--- a/test/lint/pass_lint_default_nested_with_id.sh
+++ b/test/lint/pass_lint_default_nested_with_id.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+TMP="$(mktemp -d)"
+clean() { rm -rf "$TMP"; }
+trap clean EXIT
+
+cat << 'EOF' > "$TMP/schema.json"
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com",
+  "items": {
+    "default": "Sourcemeta"
+  }
+}
+EOF
+
+"$1" lint --verbose "$TMP/schema.json"

--- a/test/lint/pass_lint_examples_nested_with_id.sh
+++ b/test/lint/pass_lint_examples_nested_with_id.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+TMP="$(mktemp -d)"
+clean() { rm -rf "$TMP"; }
+trap clean EXIT
+
+cat << 'EOF' > "$TMP/schema.json"
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com",
+  "items": {
+    "examples": [ 1, 2, 3 ]
+  }
+}
+EOF
+
+"$1" lint --verbose "$TMP/schema.json"

--- a/vendor/blaze/src/linter/valid_default.cc
+++ b/vendor/blaze/src/linter/valid_default.cc
@@ -15,7 +15,7 @@ ValidDefault::ValidDefault(Compiler compiler)
 auto ValidDefault::condition(
     const sourcemeta::core::JSON &schema, const sourcemeta::core::JSON &root,
     const sourcemeta::core::Vocabularies &vocabularies,
-    const sourcemeta::core::SchemaFrame &,
+    const sourcemeta::core::SchemaFrame &frame,
     const sourcemeta::core::SchemaFrame::Location &location,
     const sourcemeta::core::SchemaWalker &walker,
     const sourcemeta::core::SchemaResolver &resolver) const
@@ -36,11 +36,24 @@ auto ValidDefault::condition(
     return false;
   }
 
+  const auto &root_base_dialect{frame.traverse(location.root.value_or(""))
+                                    .value_or(location)
+                                    .get()
+                                    .base_dialect};
+  std::optional<std::string> default_id{location.base};
+  if (sourcemeta::core::identify(root, root_base_dialect).has_value()) {
+    // We want to only set a default identifier if the root schema does not
+    // have an explicit identifier. Otherwise, we can get into corner case
+    // when wrapping the schema
+    default_id = std::nullopt;
+  }
+
   const auto subschema{sourcemeta::core::wrap(root, location.pointer, resolver,
                                               location.dialect)};
   const auto schema_template{compile(subschema, walker, resolver,
                                      this->compiler_, Mode::FastValidation,
-                                     location.dialect, location.base)};
+                                     location.dialect, default_id)};
+
   const auto &instance{schema.at("default")};
   Evaluator evaluator;
   const std::string ref{"$ref"};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
