### PR TITLE
Don't change ordering of values when linting duplicate `enum`s

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
 vendorpull https://github.com/sourcemeta/vendorpull dea311b5bfb53b6926a4140267959ae334d3ecf4
-core https://github.com/sourcemeta/core 0be5ca5ece146a501263d85cfe226bb8330b0679
+core https://github.com/sourcemeta/core 7a18592f4b77e9932571436fbee69b34551a566a
 jsonbinpack https://github.com/sourcemeta/jsonbinpack 61a04d9d304343d8c206972225393f7ae0d5b603
 blaze https://github.com/sourcemeta/blaze c0beb606def90d0cfadff1187bfa50443493eb9d
 curl https://github.com/curl/curl curl-8_14_0

--- a/vendor/core/src/extension/alterschema/linter/duplicate_enum_values.h
+++ b/vendor/core/src/extension/alterschema/linter/duplicate_enum_values.h
@@ -29,11 +29,18 @@ public:
   }
 
   auto transform(JSON &schema) const -> void override {
-    auto collection = schema.at("enum");
-    std::sort(collection.as_array().begin(), collection.as_array().end());
-    auto last =
-        std::unique(collection.as_array().begin(), collection.as_array().end());
-    collection.erase(last, collection.as_array().end());
-    schema.at("enum").into(std::move(collection));
+    // We want to be super careful to maintain the current ordering
+    // as we delete the duplicates
+    auto &enumeration{schema.at("enum")};
+    std::unordered_set<JSON, HashJSON<JSON>> cache;
+    for (auto iterator = enumeration.as_array().cbegin();
+         iterator != enumeration.as_array().cend();) {
+      if (cache.contains(*iterator)) {
+        iterator = enumeration.erase(iterator);
+      } else {
+        cache.emplace(*iterator);
+        iterator++;
+      }
+    }
   }
 };


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
