### PR TITLE
Only write back files during `lint` if a rule applied

### DIFF
--- a/src/command_lint.cc
+++ b/src/command_lint.cc
@@ -164,9 +164,11 @@ auto sourcemeta::jsonschema::cli::lint(
             entry.first);
       }
 
-      std::ofstream output{entry.first};
-      sourcemeta::core::prettify(copy, output);
-      output << "\n";
+      if (copy != entry.second) {
+        std::ofstream output{entry.first};
+        sourcemeta::core::prettify(copy, output);
+        output << "\n";
+      }
     }
   } else {
     for (const auto &entry :

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -246,6 +246,7 @@ add_jsonschema_test_unix(lint/pass_lint_examples_nested_with_id)
 add_jsonschema_test_unix(lint/pass_lint_list_exclude)
 add_jsonschema_test_unix(lint/pass_lint_list_long)
 add_jsonschema_test_unix(lint/pass_lint_list_short)
+add_jsonschema_test_unix(lint/pass_lint_fix_no_reformat)
 
 # Encode
 add_jsonschema_test_unix(encode/pass_schema_less)

--- a/test/lint/pass_lint_fix_no_reformat.sh
+++ b/test/lint/pass_lint_fix_no_reformat.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+TMP="$(mktemp -d)"
+clean() { rm -rf "$TMP"; }
+trap clean EXIT
+
+cat << 'EOF' > "$TMP/schema.json"
+  {
+             "$schema":
+   "http://json-schema.org/draft-06/schema#",    "type"    : "string"
+}
+EOF
+
+"$1" lint "$TMP/schema.json" --fix
+
+# If no linting rule applies, we should leave the schema intact
+cat << 'EOF' > "$TMP/expected.json"
+  {
+             "$schema":
+   "http://json-schema.org/draft-06/schema#",    "type"    : "string"
+}
+EOF
+
+diff "$TMP/schema.json" "$TMP/expected.json"


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/jsonschema/issues/400
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
