### PR TITLE
chore: mention `mise` and `aqua` in the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -132,7 +132,7 @@ Where `X.Y.Z` is replaced with the desired version. For example:
 - run: jsonschema fmt path/to/schemas --check
 ```
 
-### From NPM
+### From npm
 
 ```sh
 npm install --global @sourcemeta/jsonschema
@@ -142,6 +142,12 @@ npm install --global @sourcemeta/jsonschema
 
 ```sh
 pip install sourcemeta-jsonschema
+```
+
+### From mise
+
+```sh
+mise use jsonschema
 ```
 
 ### From GitHub Releases


### PR DESCRIPTION
Please, consider mentioning `mise` and `aqua` in the readme.

Reference: `jsonschema` was recently added to the `aqua` (https://github.com/aquaproj/aqua-registry/pull/39066) and `mise` (https://github.com/jdx/mise/pull/5714) registries.

---

Thanks for this project! I was looking for a tool like this one for some time. 