### PR TITLE
Avoid linting `default` and `examples` on Draft 7 and older given a sibling `$ref`

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
 vendorpull https://github.com/sourcemeta/vendorpull dea311b5bfb53b6926a4140267959ae334d3ecf4
 core https://github.com/sourcemeta/core a19d5c0522d6d30f9bdc4c46651f7f3adfa38b33
 jsonbinpack https://github.com/sourcemeta/jsonbinpack 3a5e2e37ad664be277a34145a9efc0ab14558421
-blaze https://github.com/sourcemeta/blaze 1e5068bb415bb27499826e29fe31238239763335
+blaze https://github.com/sourcemeta/blaze 60fba0a876480852e490b1ea66694fc1c73ba7a5
 curl https://github.com/curl/curl curl-8_14_0

--- a/vendor/blaze/src/linter/valid_default.cc
+++ b/vendor/blaze/src/linter/valid_default.cc
@@ -36,6 +36,15 @@ auto ValidDefault::condition(
     return false;
   }
 
+  // We have to ignore siblings to `$ref`
+  if (vocabularies.contains("http://json-schema.org/draft-07/schema#") ||
+      vocabularies.contains("http://json-schema.org/draft-06/schema#") ||
+      vocabularies.contains("http://json-schema.org/draft-04/schema#")) {
+    if (schema.defines("$ref")) {
+      return false;
+    }
+  }
+
   const auto &root_base_dialect{frame.traverse(location.root.value_or(""))
                                     .value_or(location)
                                     .get()

--- a/vendor/blaze/src/linter/valid_examples.cc
+++ b/vendor/blaze/src/linter/valid_examples.cc
@@ -44,6 +44,15 @@ auto ValidExamples::condition(
     return false;
   }
 
+  // We have to ignore siblings to `$ref`
+  if (vocabularies.contains("http://json-schema.org/draft-07/schema#") ||
+      vocabularies.contains("http://json-schema.org/draft-06/schema#") ||
+      vocabularies.contains("http://json-schema.org/draft-04/schema#")) {
+    if (schema.defines("$ref")) {
+      return false;
+    }
+  }
+
   const auto &root_base_dialect{frame.traverse(location.root.value_or(""))
                                     .value_or(location)
                                     .get()


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/issues/425
