### PR TITLE
Add gah as an installation method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -208,6 +208,16 @@ Keep in mind that due to [Snap
 confinement](https://snapcraft.io/docs/snap-confinement) requirements, the Snap
 is only able to access files under your `$HOME` directory.
 
+### With gah
+
+If you are using [gah](https://github.com/marverix/gah):
+
+```sh
+gah install jsonschema
+```
+
+gah does not require sudo, but you need to have `$HOME/.local/bin/` in your `PATH`.
+
 ### Building from source
 
 ```sh


### PR DESCRIPTION
Hello,

first of all please allow me to thank you for your app! And the official GitHub Action is just a cherry on the top! Kudos!

So, this PR adds to the documentation the installation method using [gah](https://github.com/marverix/gah/):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.

Hope you will like it!
Br,
Marek