### PR TITLE
Fix `identation` -> `indentation` typo in the `format` documentation

### DIFF
--- a/docs/format.markdown
+++ b/docs/format.markdown
@@ -20,8 +20,8 @@ check their adherence on a continuous integration environment.
 Examples
 --------
 
-For example, consider this fictitious JSON Schema with inconsistent identation,
-spacing, keyword ordering, and more:
+For example, consider this fictitious JSON Schema with inconsistent
+indentation, spacing, keyword ordering, and more:
 
 ```json
 { "$schema":"https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/issues/440
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
