### PR TITLE
Add a `--loop` companion to the `--benchmark` option in the `validate` command

### DIFF
--- a/docs/validate.markdown
+++ b/docs/validate.markdown
@@ -7,9 +7,9 @@ Validating
 ```sh
 jsonschema validate <schema.json|.yaml> <instance.json|.jsonl|.yaml...>
   [--http/-h] [--verbose/-v] [--resolve/-r <schemas-or-directories> ...]
-  [--benchmark/-b] [--extension/-e <extension>]
+  [--benchmark/-b] [--loop <iterations>] [--extension/-e <extension>]
   [--ignore/-i <schemas-or-directories>] [--trace/-t] [--fast/-f]
-  [--default-dialect/-d <uri>] [--template/-m <template.json>] [--json/-j]
+  [--template/-m <template.json>] [--json/-j]
 ```
 
 The most popular use case of JSON Schema is to validate JSON documents. The

--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -108,6 +108,10 @@ auto sourcemeta::jsonschema::cli::validate(
   const auto fast_mode{options.contains("fast")};
   const auto benchmark{options.contains("benchmark")};
   const auto benchmark_loop{parse_loop(options)};
+  if (benchmark_loop == 0) {
+    throw std::runtime_error("The loop number cannot be zero");
+  }
+
   const auto trace{options.contains("trace")};
   const auto json_output{options.contains("json")};
 

--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -8,6 +8,7 @@
 #include <sourcemeta/blaze/evaluator.h>
 
 #include <chrono>   // std::chrono
+#include <cmath>    // for sqrt
 #include <cstdlib>  // EXIT_SUCCESS, EXIT_FAILURE
 #include <iostream> // std::cerr
 #include <string>   // std::string
@@ -63,6 +64,18 @@ auto get_schema_template(const sourcemeta::core::JSON &bundled,
 
 } // namespace
 
+// parse unsigned int option, how many loop for benchmarking
+auto benchmark_loop(const sourcemeta::core::Options &options) -> int {
+
+  int loop = 1;
+
+  if (options.contains("loop")) {
+    loop = std::stoi(options.at("loop").front().data());
+  }
+
+  return loop;
+}
+
 auto sourcemeta::jsonschema::cli::validate(
     const sourcemeta::core::Options &options) -> int {
   if (options.positional().size() < 1) {
@@ -98,6 +111,7 @@ auto sourcemeta::jsonschema::cli::validate(
 
   const auto fast_mode{options.contains("fast")};
   const auto benchmark{options.contains("benchmark")};
+  const auto bench_loop{benchmark_loop(options)};
   const auto trace{options.contains("trace")};
   const auto json_output{options.contains("json")};
 
@@ -146,6 +160,7 @@ auto sourcemeta::jsonschema::cli::validate(
             const auto duration_us{
                 std::chrono::duration_cast<std::chrono::microseconds>(
                     timestamp_end - timestamp_start)};
+
             if (subresult) {
               std::cout << "took: " << duration_us.count() << "us\n";
             } else {
@@ -219,15 +234,50 @@ auto sourcemeta::jsonschema::cli::validate(
           sourcemeta::core::empty_weak_pointer, frame};
       bool subresult{true};
       if (benchmark) {
-        const auto timestamp_start{std::chrono::high_resolution_clock::now()};
-        subresult = evaluator.validate(schema_template, instance);
-        const auto timestamp_end{std::chrono::high_resolution_clock::now()};
-        const auto duration_us{
-            std::chrono::duration_cast<std::chrono::microseconds>(
-                timestamp_end - timestamp_start)};
-        if (subresult) {
-          std::cout << "took: " << duration_us.count() << "us\n";
-        } else {
+
+        // data collection for average and standard deviation
+        double sum = 0.0, sum2 = 0.0, empty = 0.0;
+
+        // overhead evaluation, if not to optimize out!
+        for (auto i = bench_loop; i; i--) {
+          const auto start{std::chrono::high_resolution_clock::now()};
+          const auto end{std::chrono::high_resolution_clock::now()};
+          empty +=
+              (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           end - start))
+                  .count() /
+              1000.0;
+        }
+        empty /= (double)bench_loop;
+
+        // execution time evaluation
+        for (auto i = bench_loop; i; i--) {
+          const auto start{std::chrono::high_resolution_clock::now()};
+
+          // force fast evaluation
+          subresult = evaluator.validate(schema_template, instance);
+
+          const auto end{std::chrono::high_resolution_clock::now()};
+          const auto delay =
+              (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           end - start))
+                      .count() /
+                  1000.0 -
+              empty;
+
+          sum += delay;
+          sum2 += delay * delay;
+        }
+
+        // compute and show average execution time and standard deviation
+        auto avg = sum / (double)bench_loop;
+        auto stdev = sqrt(sum2 / (double)bench_loop - avg * avg);
+        std::cout << std::fixed;
+        std::cout.precision(3);
+        std::cout << "took: " << avg << " +- " << stdev << " us (" << empty
+                  << ")\n";
+
+        if (!subresult) {
           error << "error: Schema validation failure\n";
           result = false;
         }

--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -237,19 +237,21 @@ auto sourcemeta::jsonschema::cli::validate(
           const auto start{std::chrono::high_resolution_clock::now()};
           const auto end{std::chrono::high_resolution_clock::now()};
           empty +=
-              std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
-                  .count() /
+              (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           end - start)
+                           .count()) /
               1000.0;
         }
-        empty /= benchmark_loop;
+        empty /= (double)benchmark_loop;
 
         for (auto index = benchmark_loop; index; index--) {
           const auto start{std::chrono::high_resolution_clock::now()};
           subresult = evaluator.validate(schema_template, instance);
           const auto end{std::chrono::high_resolution_clock::now()};
           const auto delay =
-              std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
-                      .count() /
+              (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           end - start)
+                           .count()) /
                   1000.0 -
               empty;
 
@@ -257,8 +259,11 @@ auto sourcemeta::jsonschema::cli::validate(
           sum2 += delay * delay;
         }
 
-        auto avg = sum / benchmark_loop;
-        auto stdev = std::sqrt(sum2 / benchmark_loop - avg * avg);
+        auto avg = sum / (double)benchmark_loop;
+        auto stdev = benchmark_loop == 1
+                         ? 0.0
+                         : std::sqrt(sum2 / (double)benchmark_loop - avg * avg);
+
         std::cout << std::fixed;
         std::cout.precision(3);
         std::cout << "took: " << avg << " +- " << stdev << " us (" << empty

--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -240,22 +240,23 @@ auto sourcemeta::jsonschema::cli::validate(
         for (auto index = benchmark_loop; index; index--) {
           const auto start{std::chrono::high_resolution_clock::now()};
           const auto end{std::chrono::high_resolution_clock::now()};
-          empty +=
-              (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(
+          empty += static_cast<double>(
+                       std::chrono::duration_cast<std::chrono::nanoseconds>(
                            end - start)
                            .count()) /
-              1000.0;
+                   1000.0;
         }
-        empty /= (double)benchmark_loop;
+        empty /= static_cast<double>(benchmark_loop);
 
         for (auto index = benchmark_loop; index; index--) {
           const auto start{std::chrono::high_resolution_clock::now()};
           subresult = evaluator.validate(schema_template, instance);
           const auto end{std::chrono::high_resolution_clock::now()};
           const auto delay =
-              (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(
-                           end - start)
-                           .count()) /
+              static_cast<double>(
+                  std::chrono::duration_cast<std::chrono::nanoseconds>(end -
+                                                                       start)
+                      .count()) /
                   1000.0 -
               empty;
 
@@ -263,10 +264,12 @@ auto sourcemeta::jsonschema::cli::validate(
           sum2 += delay * delay;
         }
 
-        auto avg = sum / (double)benchmark_loop;
-        auto stdev = benchmark_loop == 1
-                         ? 0.0
-                         : std::sqrt(sum2 / (double)benchmark_loop - avg * avg);
+        auto avg = sum / static_cast<double>(benchmark_loop);
+        auto stdev =
+            benchmark_loop == 1
+                ? 0.0
+                : std::sqrt(sum2 / static_cast<double>(benchmark_loop) -
+                            avg * avg);
 
         std::cout << std::fixed;
         std::cout.precision(3);

--- a/src/main.cc
+++ b/src/main.cc
@@ -34,14 +34,15 @@ Commands:
    validate <schema.json|.yaml> <instance.json|.jsonl|.yaml...> [--http/-h]
             [--benchmark/-b] [--extension/-e <extension>]
             [--ignore/-i <schemas-or-directories>] [--trace/-t] [--fast/-f]
-            [--template/-m <template.json>] [--json/-j]
+            [--template/-m <template.json>] [--json/-j] [--loop <iterations>]
 
        Validate one or more instances against the given schema.
 
        By default, schemas are validated in exhaustive mode, which results in
        better error messages, at the expense of speed. The --fast/-f option
        makes the schema compiler optimise for speed, at the expense of error
-       messages.
+       messages. Looping in benchmark mode allows to collect the execution time
+       average and standard deviation for the fast mode on basic JSON data.
 
        You may additionally pass a pre-compiled schema template (see the
        `compile` command). However, you still need to pass the original schema
@@ -148,6 +149,7 @@ auto jsonschema_main(const std::string &program, const std::string &command,
     app.flag("fast", {"f"});
     app.option("extension", {"e"});
     app.option("template", {"m"});
+    app.option("loop", {"l"});
     app.parse(argc, argv, {.skip = 1});
     return sourcemeta::jsonschema::cli::validate(app);
   } else if (command == "metaschema") {

--- a/src/main.cc
+++ b/src/main.cc
@@ -42,7 +42,7 @@ Commands:
        better error messages, at the expense of speed. The --fast/-f option
        makes the schema compiler optimise for speed, at the expense of error
        messages. Looping in benchmark mode allows to collect the execution time
-       average and standard deviation for the fast mode on basic JSON data.
+       average and standard deviation over multiple runs.
 
        You may additionally pass a pre-compiled schema template (see the
        `compile` command). However, you still need to pass the original schema

--- a/src/main.cc
+++ b/src/main.cc
@@ -32,9 +32,10 @@ Commands:
        Print this command reference help.
 
    validate <schema.json|.yaml> <instance.json|.jsonl|.yaml...> [--http/-h]
-            [--benchmark/-b] [--extension/-e <extension>]
+            [--benchmark/-b] [--loop <iterations>]
+            [--extension/-e <extension>]
             [--ignore/-i <schemas-or-directories>] [--trace/-t] [--fast/-f]
-            [--template/-m <template.json>] [--json/-j] [--loop <iterations>]
+            [--template/-m <template.json>] [--json/-j]
 
        Validate one or more instances against the given schema.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -112,6 +112,10 @@ add_jsonschema_test_unix(validate/pass_jsonl_json)
 add_jsonschema_test_unix(validate/pass_jsonl_json_verbose)
 add_jsonschema_test_unix(validate/fail_jsonl_one_json)
 add_jsonschema_test_unix(validate/fail_jsonl_one_json_verbose)
+add_jsonschema_test_unix(validate/pass_benchmark)
+add_jsonschema_test_unix(validate/fail_benchmark)
+add_jsonschema_test_unix(validate/pass_benchmark_loop)
+add_jsonschema_test_unix(validate/fail_benchmark_zero)
 
 # Metaschema
 add_jsonschema_test_unix(metaschema/pass_trace)

--- a/test/validate/fail_benchmark.sh
+++ b/test/validate/fail_benchmark.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+TMP="$(mktemp -d)"
+clean() { rm -rf "$TMP"; }
+trap clean EXIT
+
+cat << 'EOF' > "$TMP/schema.json"
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "string"
+    }
+  }
+}
+EOF
+
+cat << 'EOF' > "$TMP/instance.json"
+{ "foo": 1 }
+EOF
+
+"$1" validate "$TMP/schema.json" "$TMP/instance.json" --benchmark > "$TMP/output.txt" 2>&1 \
+  && CODE="$?" || CODE="$?"
+test "$CODE" = "2" || exit 1
+
+if ! grep -E "^took: [0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)$" "$TMP/output.txt" > /dev/null
+then
+  cat "$TMP/output.txt" >&2
+  exit 1
+fi

--- a/test/validate/fail_benchmark_zero.sh
+++ b/test/validate/fail_benchmark_zero.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+TMP="$(mktemp -d)"
+clean() { rm -rf "$TMP"; }
+trap clean EXIT
+
+cat << 'EOF' > "$TMP/schema.json"
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "string"
+    }
+  }
+}
+EOF
+
+cat << 'EOF' > "$TMP/instance.json"
+{ "foo": "bar" }
+EOF
+
+"$1" validate "$TMP/schema.json" "$TMP/instance.json" --benchmark --loop 0 > "$TMP/output.txt" 2>&1 \
+  && CODE="$?" || CODE="$?"
+test "$CODE" = "1" || exit 1
+
+cat << EOF > "$TMP/expected.txt"
+error: The loop number cannot be zero
+EOF
+
+diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/validate/pass_benchmark.sh
+++ b/test/validate/pass_benchmark.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+TMP="$(mktemp -d)"
+clean() { rm -rf "$TMP"; }
+trap clean EXIT
+
+cat << 'EOF' > "$TMP/schema.json"
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "string"
+    }
+  }
+}
+EOF
+
+cat << 'EOF' > "$TMP/instance.json"
+{ "foo": "bar" }
+EOF
+
+"$1" validate "$TMP/schema.json" "$TMP/instance.json" --benchmark > "$TMP/output.txt"
+
+if ! grep -E "^took: [0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)$" "$TMP/output.txt" > /dev/null
+then
+  cat "$TMP/output.txt" >&2
+  exit 1
+fi

--- a/test/validate/pass_benchmark_loop.sh
+++ b/test/validate/pass_benchmark_loop.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+TMP="$(mktemp -d)"
+clean() { rm -rf "$TMP"; }
+trap clean EXIT
+
+cat << 'EOF' > "$TMP/schema.json"
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "string"
+    }
+  }
+}
+EOF
+
+cat << 'EOF' > "$TMP/instance.json"
+{ "foo": "bar" }
+EOF
+
+"$1" validate "$TMP/schema.json" "$TMP/instance.json" --benchmark --loop 1000 > "$TMP/output.txt"
+
+if ! grep -E "^took: [0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)$" "$TMP/output.txt" > /dev/null
+then
+  cat "$TMP/output.txt" >&2
+  exit 1
+fi


### PR DESCRIPTION
This PR replaces #349.
It updates the code wrt the new way options are managed in the CLI.
I'm looking forward to see if the CI is happy with it…