### PR TITLE
Make `bundle` add a top-level identifier when bundling anonymous schemas

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
 vendorpull https://github.com/sourcemeta/vendorpull dea311b5bfb53b6926a4140267959ae334d3ecf4
-core https://github.com/sourcemeta/core 6d73442ce800d7a488e0432ce888d5f726b47c91
+core https://github.com/sourcemeta/core 1eff092153241c8e015adc96ef4bd104aa8d1254
 jsonbinpack https://github.com/sourcemeta/jsonbinpack 56dd83ba8483391a694c017ceceafa46cf743259
 blaze https://github.com/sourcemeta/blaze 8a1c473c5dc952185ebb6d7d279a776f5418afd4
 curl https://github.com/curl/curl curl-8_14_0

--- a/test/bundle/pass_resolve_no_identifier.sh
+++ b/test/bundle/pass_resolve_no_identifier.sh
@@ -26,6 +26,7 @@ EOF
 cat << EOF > "$TMP/expected.json"
 {
   "\$schema": "https://json-schema.org/draft/2020-12/schema",
+  "\$id": "file://$(realpath "$TMP")/schema.json",
   "\$ref": "./nested.json",
   "\$defs": {
     "file://$(realpath "$TMP")/nested.json": {

--- a/test/ci/pass_bundle_http.sh
+++ b/test/ci/pass_bundle_http.sh
@@ -18,23 +18,24 @@ EOF
 
 "$1" bundle "$TMP/schema.json" --http > "$TMP/result.json"
 
-cat << 'EOF' > "$TMP/expected.json"
+cat << EOF > "$TMP/expected.json"
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "\$schema": "http://json-schema.org/draft-07/schema#",
+  "\$id": "file://$(realpath "$TMP")/schema.json",
   "allOf": [
     {
-      "$ref": "https://schemas.sourcemeta.com/jsonschema/draft4/schema.json"
+      "\$ref": "https://schemas.sourcemeta.com/jsonschema/draft4/schema.json"
     }
   ],
   "definitions": {
     "https://schemas.sourcemeta.com/jsonschema/draft4/schema.json": {
-      "$schema": "http://json-schema.org/draft-04/schema#",
+      "\$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://schemas.sourcemeta.com/jsonschema/draft4/schema.json",
       "description": "Core schema meta-schema",
       "default": {},
       "type": "object",
       "properties": {
-        "$schema": {
+        "\$schema": {
           "type": "string"
         },
         "id": {
@@ -50,14 +51,14 @@ cat << 'EOF' > "$TMP/expected.json"
         "type": {
           "anyOf": [
             {
-              "$ref": "#/definitions/simpleTypes"
+              "\$ref": "#/definitions/simpleTypes"
             },
             {
               "type": "array",
               "minItems": 1,
               "uniqueItems": true,
               "items": {
-                "$ref": "#/definitions/simpleTypes"
+                "\$ref": "#/definitions/simpleTypes"
               }
             }
           ]
@@ -68,16 +69,16 @@ cat << 'EOF' > "$TMP/expected.json"
           "uniqueItems": true
         },
         "allOf": {
-          "$ref": "#/definitions/schemaArray"
+          "\$ref": "#/definitions/schemaArray"
         },
         "anyOf": {
-          "$ref": "#/definitions/schemaArray"
+          "\$ref": "#/definitions/schemaArray"
         },
         "oneOf": {
-          "$ref": "#/definitions/schemaArray"
+          "\$ref": "#/definitions/schemaArray"
         },
         "not": {
-          "$ref": ""
+          "\$ref": ""
         },
         "exclusiveMaximum": {
           "default": false,
@@ -106,16 +107,16 @@ cat << 'EOF' > "$TMP/expected.json"
           "type": "string"
         },
         "maxLength": {
-          "$ref": "#/definitions/positiveInteger"
+          "\$ref": "#/definitions/positiveInteger"
         },
         "minLength": {
-          "$ref": "#/definitions/positiveIntegerDefault0"
+          "\$ref": "#/definitions/positiveIntegerDefault0"
         },
         "maxItems": {
-          "$ref": "#/definitions/positiveInteger"
+          "\$ref": "#/definitions/positiveInteger"
         },
         "minItems": {
-          "$ref": "#/definitions/positiveIntegerDefault0"
+          "\$ref": "#/definitions/positiveIntegerDefault0"
         },
         "uniqueItems": {
           "default": false,
@@ -125,10 +126,10 @@ cat << 'EOF' > "$TMP/expected.json"
           "default": {},
           "anyOf": [
             {
-              "$ref": ""
+              "\$ref": ""
             },
             {
-              "$ref": "#/definitions/schemaArray"
+              "\$ref": "#/definitions/schemaArray"
             }
           ]
         },
@@ -139,31 +140,31 @@ cat << 'EOF' > "$TMP/expected.json"
               "type": "boolean"
             },
             {
-              "$ref": ""
+              "\$ref": ""
             }
           ]
         },
         "required": {
-          "$ref": "#/definitions/stringArray"
+          "\$ref": "#/definitions/stringArray"
         },
         "maxProperties": {
-          "$ref": "#/definitions/positiveInteger"
+          "\$ref": "#/definitions/positiveInteger"
         },
         "minProperties": {
-          "$ref": "#/definitions/positiveIntegerDefault0"
+          "\$ref": "#/definitions/positiveIntegerDefault0"
         },
         "properties": {
           "default": {},
           "type": "object",
           "additionalProperties": {
-            "$ref": ""
+            "\$ref": ""
           }
         },
         "patternProperties": {
           "default": {},
           "type": "object",
           "additionalProperties": {
-            "$ref": ""
+            "\$ref": ""
           }
         },
         "additionalProperties": {
@@ -173,7 +174,7 @@ cat << 'EOF' > "$TMP/expected.json"
               "type": "boolean"
             },
             {
-              "$ref": ""
+              "\$ref": ""
             }
           ]
         },
@@ -182,10 +183,10 @@ cat << 'EOF' > "$TMP/expected.json"
           "additionalProperties": {
             "anyOf": [
               {
-                "$ref": ""
+                "\$ref": ""
               },
               {
-                "$ref": "#/definitions/stringArray"
+                "\$ref": "#/definitions/stringArray"
               }
             ]
           }
@@ -194,7 +195,7 @@ cat << 'EOF' > "$TMP/expected.json"
           "default": {},
           "type": "object",
           "additionalProperties": {
-            "$ref": ""
+            "\$ref": ""
           }
         }
       },
@@ -210,7 +211,7 @@ cat << 'EOF' > "$TMP/expected.json"
         "positiveIntegerDefault0": {
           "allOf": [
             {
-              "$ref": "#/definitions/positiveInteger"
+              "\$ref": "#/definitions/positiveInteger"
             },
             {
               "default": 0
@@ -221,7 +222,7 @@ cat << 'EOF' > "$TMP/expected.json"
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": ""
+            "\$ref": ""
           }
         },
         "simpleTypes": {

--- a/vendor/core/src/core/jsonschema/bundle.cc
+++ b/vendor/core/src/core/jsonschema/bundle.cc
@@ -258,6 +258,17 @@ auto bundle(JSON &schema, const SchemaWalker &walker,
     return;
   }
 
+  // If the schema identifier is implicit, add it to the top-level of the
+  // bundled schema. Otherwise, potential relative references based on this
+  // implicit base URI will likely not resolve unless end users happen to
+  // know that this implicit base URI is.
+  if (default_id.has_value() &&
+      !identify(schema, resolver, SchemaIdentificationStrategy::Strict,
+                default_dialect)
+           .has_value()) {
+    reidentify(schema, default_id.value(), resolver, default_dialect);
+  }
+
   const auto vocabularies{
       sourcemeta::core::vocabularies(schema, resolver, default_dialect)};
   if (vocabularies.contains(


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/jsonschema/issues/452
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
