### PR TITLE
Expand `unnecessary_allof_wrapper_*` rules to permit branches with the same keywords

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
-core https://github.com/sourcemeta/core 649a3b38ba4704927b78646eac5f22a2fc3997d7
+core https://github.com/sourcemeta/core b56040409a54a6ef85c47f78c087096a9ca04620
 jsonbinpack https://github.com/sourcemeta/jsonbinpack 56dd83ba8483391a694c017ceceafa46cf743259
 blaze https://github.com/sourcemeta/blaze d574a7c08c3b398b7a0a62e624236eff01cc2bd8
 curl https://github.com/curl/curl curl-8_14_0

--- a/test/lint/pass_lint_list_exclude.sh
+++ b/test/lint/pass_lint_list_exclude.sh
@@ -152,10 +152,10 @@ unknown_keywords_prefix
   Future versions of JSON Schema will refuse to evaluate unknown keywords that don't have an x- prefix
 
 unnecessary_allof_wrapper_draft
-  Wrapping any keyword other than `$ref` in `allOf` is unnecessary and may even introduce a minor evaluation performance overhead
+  Wrapping keywords other than `$ref` in `allOf` is often unnecessary and may even introduce a minor evaluation performance overhead
 
 unnecessary_allof_wrapper_modern
-  Wrapping any keyword in `allOf` is unnecessary and may even introduce a minor evaluation performance overhead
+  Wrapping keywords in `allOf` is often unnecessary and may even introduce a minor evaluation performance overhead
 
 unnecessary_allof_wrapper_properties
   Avoid unnecessarily wrapping object `properties` in `allOf` as it may introduce a minor evaluation performance overhead and even confuse documentation generators

--- a/test/lint/pass_lint_list_long.sh
+++ b/test/lint/pass_lint_list_long.sh
@@ -158,10 +158,10 @@ unknown_keywords_prefix
   Future versions of JSON Schema will refuse to evaluate unknown keywords that don't have an x- prefix
 
 unnecessary_allof_wrapper_draft
-  Wrapping any keyword other than `$ref` in `allOf` is unnecessary and may even introduce a minor evaluation performance overhead
+  Wrapping keywords other than `$ref` in `allOf` is often unnecessary and may even introduce a minor evaluation performance overhead
 
 unnecessary_allof_wrapper_modern
-  Wrapping any keyword in `allOf` is unnecessary and may even introduce a minor evaluation performance overhead
+  Wrapping keywords in `allOf` is often unnecessary and may even introduce a minor evaluation performance overhead
 
 unnecessary_allof_wrapper_properties
   Avoid unnecessarily wrapping object `properties` in `allOf` as it may introduce a minor evaluation performance overhead and even confuse documentation generators

--- a/test/lint/pass_lint_list_short.sh
+++ b/test/lint/pass_lint_list_short.sh
@@ -158,10 +158,10 @@ unknown_keywords_prefix
   Future versions of JSON Schema will refuse to evaluate unknown keywords that don't have an x- prefix
 
 unnecessary_allof_wrapper_draft
-  Wrapping any keyword other than `$ref` in `allOf` is unnecessary and may even introduce a minor evaluation performance overhead
+  Wrapping keywords other than `$ref` in `allOf` is often unnecessary and may even introduce a minor evaluation performance overhead
 
 unnecessary_allof_wrapper_modern
-  Wrapping any keyword in `allOf` is unnecessary and may even introduce a minor evaluation performance overhead
+  Wrapping keywords in `allOf` is often unnecessary and may even introduce a minor evaluation performance overhead
 
 unnecessary_allof_wrapper_properties
   Avoid unnecessarily wrapping object `properties` in `allOf` as it may introduce a minor evaluation performance overhead and even confuse documentation generators

--- a/test/lint/pass_lint_list_strict.sh
+++ b/test/lint/pass_lint_list_strict.sh
@@ -161,10 +161,10 @@ unknown_keywords_prefix
   Future versions of JSON Schema will refuse to evaluate unknown keywords that don't have an x- prefix
 
 unnecessary_allof_wrapper_draft
-  Wrapping any keyword other than `$ref` in `allOf` is unnecessary and may even introduce a minor evaluation performance overhead
+  Wrapping keywords other than `$ref` in `allOf` is often unnecessary and may even introduce a minor evaluation performance overhead
 
 unnecessary_allof_wrapper_modern
-  Wrapping any keyword in `allOf` is unnecessary and may even introduce a minor evaluation performance overhead
+  Wrapping keywords in `allOf` is often unnecessary and may even introduce a minor evaluation performance overhead
 
 unnecessary_allof_wrapper_properties
   Avoid unnecessarily wrapping object `properties` in `allOf` as it may introduce a minor evaluation performance overhead and even confuse documentation generators

--- a/vendor/core/src/extension/alterschema/linter/unnecessary_allof_wrapper_draft.h
+++ b/vendor/core/src/extension/alterschema/linter/unnecessary_allof_wrapper_draft.h
@@ -1,10 +1,11 @@
 class UnnecessaryAllOfWrapperDraft final : public SchemaTransformRule {
 public:
   UnnecessaryAllOfWrapperDraft()
-      : SchemaTransformRule{"unnecessary_allof_wrapper_draft",
-                            "Wrapping any keyword other than `$ref` in `allOf` "
-                            "is unnecessary and may even introduce a minor "
-                            "evaluation performance overhead"} {};
+      : SchemaTransformRule{
+            "unnecessary_allof_wrapper_draft",
+            "Wrapping keywords other than `$ref` in `allOf` "
+            "is often unnecessary and may even introduce a minor "
+            "evaluation performance overhead"} {};
 
   [[nodiscard]] auto
   condition(const sourcemeta::core::JSON &schema,
@@ -12,7 +13,7 @@ public:
             const sourcemeta::core::Vocabularies &vocabularies,
             const sourcemeta::core::SchemaFrame &,
             const sourcemeta::core::SchemaFrame::Location &,
-            const sourcemeta::core::SchemaWalker &walker,
+            const sourcemeta::core::SchemaWalker &,
             const sourcemeta::core::SchemaResolver &) const
       -> sourcemeta::core::SchemaTransformRule::Result override {
     ONLY_CONTINUE_IF(contains_any(vocabularies,
@@ -24,36 +25,48 @@ public:
 
     std::vector<Pointer> locations;
     const auto &all_of{schema.at("allOf")};
-    bool multi_ref_only{all_of.size() > 1};
+    bool same_keywords{all_of.size() > 1};
     for (std::size_t index = 0; index < all_of.size(); index++) {
       const auto &entry{all_of.at(index)};
-      if (entry.is_object()) {
-        // It is dangerous to extract type-specific keywords from a schema that
-        // declares a type into another schema that also declares a type if
-        // the types are different. As we might lead to those type-keywords
-        // getting incorrectly removed if they don't apply to the target type
-        if (schema.defines("type") && entry.defines("type") &&
-            // TODO: Ideally we also check for intersection of types in type
-            // arrays or whether one is contained in the other
-            schema.at("type") != entry.at("type")) {
-          multi_ref_only = false;
-          continue;
+      if (!entry.is_object()) {
+        same_keywords = false;
+        continue;
+      }
+
+      // It is dangerous to extract type-specific keywords from a schema that
+      // declares a type into another schema that also declares a type if
+      // the types are different. As we might lead to those type-keywords
+      // getting incorrectly removed if they don't apply to the target type
+      if (schema.defines("type") && entry.defines("type") &&
+          // TODO: Ideally we also check for intersection of types in type
+          // arrays or whether one is contained in the other
+          schema.at("type") != entry.at("type")) {
+        same_keywords = false;
+        continue;
+      }
+
+      for (const auto &subentry : entry.as_object()) {
+        // If we have any new keyword in a branch after the first,
+        // then we probably need to collapse
+        if (index > 0 && same_keywords) {
+          const auto &previous{all_of.at(index - 1)};
+          if (previous.is_object()) {
+            for (const auto &other : previous.as_object()) {
+              if (!entry.defines(other.first)) {
+                same_keywords = false;
+                break;
+              }
+            }
+          }
         }
 
-        for (const auto &subentry : entry.as_object()) {
-          if (walker(subentry.first, vocabularies).type !=
-              SchemaKeywordType::Reference) {
-            multi_ref_only = false;
-          }
-
-          if (subentry.first != "$ref" && !schema.defines(subentry.first)) {
-            locations.push_back(Pointer{"allOf", index, subentry.first});
-          }
+        if (subentry.first != "$ref" && !schema.defines(subentry.first)) {
+          locations.push_back(Pointer{"allOf", index, subentry.first});
         }
       }
     }
 
-    ONLY_CONTINUE_IF(!locations.empty() && !multi_ref_only);
+    ONLY_CONTINUE_IF(!locations.empty() && !same_keywords);
     return APPLIES_TO_POINTERS(std::move(locations));
   }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
