### PR TITLE
Improve error when a `lint` rule would infinitely loop on auto-fix

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
-core https://github.com/sourcemeta/core b56040409a54a6ef85c47f78c087096a9ca04620
+core https://github.com/sourcemeta/core b3952309174a77770354d7949030a5dcbf0e116e
 jsonbinpack https://github.com/sourcemeta/jsonbinpack 56dd83ba8483391a694c017ceceafa46cf743259
 blaze https://github.com/sourcemeta/blaze d574a7c08c3b398b7a0a62e624236eff01cc2bd8
 curl https://github.com/curl/curl curl-8_14_0

--- a/test/lint/fail_lint_fix_broken_reference.sh
+++ b/test/lint/fail_lint_fix_broken_reference.sh
@@ -40,12 +40,14 @@ error: Could not autofix the schema without breaking its internal references
   at $(realpath "$TMP")/schema.json
   at schema location "/properties/bar/\$ref"
 
-We are working hard to improve the autofixing functionality to re-phrase
-references in all possible edge cases
+This is an unexpected error, as making the auto-fix functionality work in all
+cases is tricky. We are working hard to improve the auto-fixing functionality
+to handle all possible edge cases, but for now, try again without \`--fix/-f\`
+and apply the suggestions by hand.
 
-For now, try again without \`--fix/-f\` and applying the suggestions by hand
+Also consider consider reporting this problematic case to the issue tracker,
+so we can add it to the test suite and fix it:
 
-Also consider consider reporting this problematic case to the issue tracker:
 https://github.com/sourcemeta/jsonschema/issues
 EOF
 

--- a/vendor/core/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
+++ b/vendor/core/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
@@ -159,6 +159,31 @@ public:
   }
 };
 
+/// @ingroup jsonschema
+/// An error that signifies that a transform rule was applied more than once
+class SOURCEMETA_CORE_JSONSCHEMA_EXPORT SchemaTransformRuleProcessedTwiceError
+    : public std::exception {
+public:
+  SchemaTransformRuleProcessedTwiceError(std::string name, Pointer location)
+      : name_{std::move(name)}, location_{std::move(location)} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return "Transformation rules must only be processed once";
+  }
+
+  [[nodiscard]] auto name() const noexcept -> const auto & {
+    return this->name_;
+  }
+
+  [[nodiscard]] auto location() const noexcept -> const auto & {
+    return this->location_;
+  }
+
+private:
+  std::string name_;
+  Pointer location_;
+};
+
 #if defined(_MSC_VER)
 #pragma warning(default : 4251 4275)
 #endif

--- a/vendor/core/src/core/jsonschema/transformer.cc
+++ b/vendor/core/src/core/jsonschema/transformer.cc
@@ -1,11 +1,10 @@
 #include <sourcemeta/core/jsonschema.h>
 #include <sourcemeta/core/uri.h>
 
-#include <cassert>   // assert
-#include <set>       // std::set
-#include <sstream>   // std::ostringstream
-#include <stdexcept> // std::runtime_error
-#include <utility>   // std::move, std::pair
+#include <cassert> // assert
+#include <set>     // std::set
+#include <sstream> // std::ostringstream
+#include <utility> // std::move, std::pair
 
 namespace {
 
@@ -181,11 +180,8 @@ auto SchemaTransformer::apply(
 
         std::pair<const JSON *, const JSON::String *> mark{&current, &name};
         if (processed_rules.contains(mark)) {
-          // TODO: Throw a better custom error that also highlights the schema
-          // location
-          std::ostringstream error;
-          error << "Rules must only be processed once: " << name;
-          throw std::runtime_error(error.str());
+          throw SchemaTransformRuleProcessedTwiceError(name,
+                                                       entry.second.pointer);
         }
 
         // Identify and try to address broken references, if any


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/issues/463
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
