### PR TITLE
Dockerfile: also disable SIMD support on Docker binaries as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ COPY src /source/src
 COPY vendor /source/vendor
 COPY CMakeLists.txt /source/CMakeLists.txt
 
-RUN cmake -S /source -B ./build -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_SHARED_LIBS:BOOL=OFF
+RUN cmake -S /source -B ./build \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DBUILD_SHARED_LIBS:BOOL=OFF \
+  -DJSONSCHEMA_PORTABLE:BOOL=ON
 RUN cmake --build /build --config Release --parallel 4
 RUN cmake --install /build --prefix /usr/local --config Release --verbose --component sourcemeta_jsonschema
 


### PR DESCRIPTION
Docker binaries are being used in a similar way as CI binaries, so they should receive the same treatment.

While we're at it, add line breaks.

See: https://github.com/sourcemeta/jsonschema/issues/304