### PR TITLE
Add a lint rule to detect invalid local `$ref`s

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
-core https://github.com/sourcemeta/core eff08dbc8da88db93c52643ff2eb84db1741b662
+core https://github.com/sourcemeta/core a554b188ac86706cd9ba3dcf8cf4b267f86e2043
 jsonbinpack https://github.com/sourcemeta/jsonbinpack abd40e41050d14d74af1fddb5c397de5cca3b13c
 blaze https://github.com/sourcemeta/blaze e6da51b14d4a187b03c175af2c87395f9c150d15
 hydra https://github.com/sourcemeta/hydra af9f2c54709d620872ead0c3f8f683c15a0fa702

--- a/test/lint/pass_lint_list_exclude.sh
+++ b/test/lint/pass_lint_list_exclude.sh
@@ -154,6 +154,9 @@ unevaluated_properties_default
 unknown_keywords_prefix
   Future versions of JSON Schema will refuse to evaluate unknown keywords that don't have an x- prefix
 
+unknown_local_ref
+  Local references that point to unknown locations are invalid and will result in evaluation failures
+
 unnecessary_allof_ref_wrapper_draft
   Wrapping `$ref` in `allOf` is only necessary if there are other sibling keywords
 
@@ -166,7 +169,7 @@ unsatisfiable_max_contains
 unsatisfiable_min_properties
   Setting `minProperties` to a number less than `required` does not add any further constraint
 
-Number of rules: 52
+Number of rules: 53
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/lint/pass_lint_list_long.sh
+++ b/test/lint/pass_lint_list_long.sh
@@ -160,6 +160,9 @@ unevaluated_properties_default
 unknown_keywords_prefix
   Future versions of JSON Schema will refuse to evaluate unknown keywords that don't have an x- prefix
 
+unknown_local_ref
+  Local references that point to unknown locations are invalid and will result in evaluation failures
+
 unnecessary_allof_ref_wrapper_draft
   Wrapping `$ref` in `allOf` is only necessary if there are other sibling keywords
 
@@ -172,7 +175,7 @@ unsatisfiable_max_contains
 unsatisfiable_min_properties
   Setting `minProperties` to a number less than `required` does not add any further constraint
 
-Number of rules: 54
+Number of rules: 55
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/lint/pass_lint_list_short.sh
+++ b/test/lint/pass_lint_list_short.sh
@@ -160,6 +160,9 @@ unevaluated_properties_default
 unknown_keywords_prefix
   Future versions of JSON Schema will refuse to evaluate unknown keywords that don't have an x- prefix
 
+unknown_local_ref
+  Local references that point to unknown locations are invalid and will result in evaluation failures
+
 unnecessary_allof_ref_wrapper_draft
   Wrapping `$ref` in `allOf` is only necessary if there are other sibling keywords
 
@@ -172,7 +175,7 @@ unsatisfiable_max_contains
 unsatisfiable_min_properties
   Setting `minProperties` to a number less than `required` does not add any further constraint
 
-Number of rules: 54
+Number of rules: 55
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/lint/pass_lint_list_strict.sh
+++ b/test/lint/pass_lint_list_strict.sh
@@ -163,6 +163,9 @@ unevaluated_properties_default
 unknown_keywords_prefix
   Future versions of JSON Schema will refuse to evaluate unknown keywords that don't have an x- prefix
 
+unknown_local_ref
+  Local references that point to unknown locations are invalid and will result in evaluation failures
+
 unnecessary_allof_ref_wrapper_draft
   Wrapping `$ref` in `allOf` is only necessary if there are other sibling keywords
 
@@ -175,7 +178,7 @@ unsatisfiable_max_contains
 unsatisfiable_min_properties
   Setting `minProperties` to a number less than `required` does not add any further constraint
 
-Number of rules: 55
+Number of rules: 56
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/vendor/core/src/extension/alterschema/CMakeLists.txt
+++ b/vendor/core/src/extension/alterschema/CMakeLists.txt
@@ -68,6 +68,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME alterschema
     linter/draft_ref_siblings.h
     linter/definitions_to_defs.h
     linter/unknown_keywords_prefix.h
+    linter/unknown_local_ref.h
     linter/non_applicable_enum_validation_keywords.h
 
     # Strict

--- a/vendor/core/src/extension/alterschema/alterschema.cc
+++ b/vendor/core/src/extension/alterschema/alterschema.cc
@@ -99,6 +99,7 @@ inline auto APPLIES_TO_POINTERS(std::vector<Pointer> &&keywords)
 #include "linter/unevaluated_items_default.h"
 #include "linter/unevaluated_properties_default.h"
 #include "linter/unknown_keywords_prefix.h"
+#include "linter/unknown_local_ref.h"
 #include "linter/unnecessary_allof_ref_wrapper_draft.h"
 #include "linter/unnecessary_allof_ref_wrapper_modern.h"
 #include "linter/unsatisfiable_max_contains.h"
@@ -148,6 +149,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
   bundle.add<ExclusiveMinimumNumberAndMinimum>();
   bundle.add<DraftRefSiblings>();
   bundle.add<UnknownKeywordsPrefix>();
+  bundle.add<UnknownLocalRef>();
 
   if (mode == AlterSchemaMode::StaticAnalysis) {
     bundle.add<BooleanTrue>();

--- a/vendor/core/src/extension/alterschema/linter/unknown_local_ref.h
+++ b/vendor/core/src/extension/alterschema/linter/unknown_local_ref.h
@@ -1,0 +1,59 @@
+class UnknownLocalRef final : public SchemaTransformRule {
+public:
+  UnknownLocalRef()
+      : SchemaTransformRule{
+            "unknown_local_ref",
+            "Local references that point to unknown locations are invalid and "
+            "will result in evaluation failures"} {};
+
+  [[nodiscard]] auto
+  condition(const JSON &schema, const JSON &, const Vocabularies &vocabularies,
+            const SchemaFrame &frame, const SchemaFrame::Location &location,
+            const SchemaWalker &, const SchemaResolver &) const
+      -> SchemaTransformRule::Result override {
+    ONLY_CONTINUE_IF(contains_any(
+        vocabularies,
+        {"https://json-schema.org/draft/2020-12/vocab/core",
+         "https://json-schema.org/draft/2019-09/vocab/core",
+         // In JSON Schema Draft 7 and older, `$ref` overrides siblings.
+         // However, we do not need to worry about this case here, as if the
+         // `$ref` points to an unknown local location, the entire schema is
+         // invalid anyway. We just help at least making the schema valid
+         "http://json-schema.org/draft-07/schema#",
+         "http://json-schema.org/draft-06/schema#",
+         "http://json-schema.org/draft-04/schema#",
+         "http://json-schema.org/draft-03/schema#"}));
+    ONLY_CONTINUE_IF(schema.is_object() && schema.defines("$ref") &&
+                     schema.at("$ref").is_string());
+
+    // Find the keyword location entry
+    const auto absolute_ref_pointer{location.pointer.concat({"$ref"})};
+    const auto reference_entry{frame.references().find(
+        {SchemaReferenceType::Static, absolute_ref_pointer})};
+    ONLY_CONTINUE_IF(reference_entry != frame.references().end());
+
+    // If the keyword has no fragment, continue
+    const auto &reference_fragment{reference_entry->second.fragment};
+    ONLY_CONTINUE_IF(reference_fragment.has_value());
+
+    // Only continue if the reference target does not exist
+    const auto target_location{frame.locations().find(
+        {SchemaReferenceType::Static, reference_entry->second.destination})};
+    ONLY_CONTINUE_IF(target_location == frame.locations().end());
+
+    // If there is a base beyond the fragment, the base must exist.
+    // Otherwise it is likely an external reference?
+    const auto &reference_base{reference_entry->second.base};
+    if (reference_base.has_value()) {
+      const auto base_location{frame.locations().find(
+          {SchemaReferenceType::Static, reference_base.value()})};
+      ONLY_CONTINUE_IF(base_location != frame.locations().end());
+    }
+
+    return APPLIES_TO_KEYWORDS("$ref");
+  }
+
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("$ref");
+  }
+};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
