### PR TITLE
Support cases where platform.machine() is 'amd64' instead of 'x86_64'

### DIFF
--- a/pip-deploy.sh
+++ b/pip-deploy.sh
@@ -49,8 +49,13 @@ cat > "$STAGE/$PKG/__main__.py" << 'EOF'
 import os, platform, subprocess, sys
 
 def main():
+    arch_map = {
+        'amd64': 'x86_64'
+    }
+
     system = platform.system().lower()
     arch   = platform.machine().lower()
+    arch   = arch_map.get(arch, arch)
     key    = f"{system}-{arch}"
     fn     = f"jsonschema-{key}.exe" if system=="windows" else f"jsonschema-{key}"
     path   = os.path.join(os.path.dirname(__file__), fn)


### PR DESCRIPTION
This updates `__main__.py` in the PyPi version to work when `platform.system().lower()` returns `'amd64'`.