### PR TITLE
Add an Alpine test Dockerfile for development purposes

### DIFF
--- a/Dockerfile.test.alpine
+++ b/Dockerfile.test.alpine
@@ -1,0 +1,22 @@
+FROM alpine:3.21
+RUN apk add --no-cache cmake make g++ zsh bash jq
+WORKDIR /src
+COPY CMakeLists.txt .
+COPY cmake cmake
+COPY src src
+COPY test test
+COPY vendor vendor
+COPY completion completion
+COPY VERSION VERSION
+COPY package.json package.json
+COPY package-lock.json package-lock.json
+COPY action.yml action.yml
+COPY README.markdown README.markdown
+RUN cmake -S . -B ./build \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DJSONSCHEMA_TESTS:BOOL=ON
+RUN cmake --build ./build --config Release --parallel 4
+RUN cmake --install ./build --prefix ./build/dist --config Release --verbose \
+  --component sourcemeta_jsonschema
+RUN cd ./build && ctest --build-config Release --output-on-failure --parallel
+RUN cpack --config build/CPackConfig.cmake -B build/out -C Release

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CTEST = ctest
 CPACK = cpack
 NPM = npm
 NODE = node
+DOCKER = docker
 
 # Options
 PRESET = Debug
@@ -51,6 +52,9 @@ npm-pack: node_modules .always
 
 npm-publish: npm-pack
 	$(NPM) publish
+
+alpine: .always
+	$(DOCKER) build --progress plain --file Dockerfile.test.alpine .
 
 # For NMake, which doesn't support .PHONY
 .always:

--- a/vendorpull.mask
+++ b/vendorpull.mask
@@ -32,3 +32,4 @@ eslint.config.mjs
 package.json
 package-lock.json
 npm
+Dockerfile.test.alpine


### PR DESCRIPTION
Useful to quickly test the project on Alpine.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
