### PR TITLE
Print simple progress status when running `lint --fix`

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,7 +1,7 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
-core https://github.com/sourcemeta/core 6d1acddbe4888f0ca3b98a13f13f7b1fa44be964
-jsonbinpack https://github.com/sourcemeta/jsonbinpack 5e0e10c4550a2e5d4c13af037d3bb295acb19726
-blaze https://github.com/sourcemeta/blaze ed6889f138b0b446cce79e5adb4c7facaefd6846
+core https://github.com/sourcemeta/core fe450b982907f99e542a0cfc78bc60d2b600ff7a
+jsonbinpack https://github.com/sourcemeta/jsonbinpack 3898774a945ebf7392bad8a9015ead97a0518a19
+blaze https://github.com/sourcemeta/blaze 1f226e3e71036d65c7855027de7c9fc42125b108
 hydra https://github.com/sourcemeta/hydra c5f9542519bce7b6ac90ec8638329ef53aa46450
-codegen https://github.com/sourcemeta/codegen f1c1cc50799b69ce8a5bb970e606f229b7fe60a1
+codegen https://github.com/sourcemeta/codegen 7733b3071cb140bc0d09406ebb9c3f306d71f7bf
 ctrf https://github.com/ctrf-io/ctrf 93ea827d951390190171d37443bff169cf47c808

--- a/src/command_canonicalize.cc
+++ b/src/command_canonicalize.cc
@@ -14,7 +14,8 @@ namespace {
 auto transformer_callback_noop(
     const sourcemeta::core::Pointer &, const std::string_view,
     const std::string_view,
-    const sourcemeta::core::SchemaTransformRule::Result &) -> void {}
+    const sourcemeta::core::SchemaTransformRule::Result &, const bool) -> void {
+}
 } // namespace
 
 auto sourcemeta::jsonschema::canonicalize(

--- a/test/lint/fail_draft4_x_keyword_ref_target_fix.sh
+++ b/test/lint/fail_draft4_x_keyword_ref_target_fix.sh
@@ -37,6 +37,7 @@ test "$CODE" = "1" || exit 1
 
 # After --fix elevates the allOf wrapper, the path changes
 cat << EOF > "$TMP/expected.txt"
+..
 error: The referenced schema is not considered to be a valid subschema given the dialect and vocabularies in use
   at identifier file://$(realpath "$TMP")/schema.json#/additionalProperties/x-this-is-invalid/\$defs/test
   at file path $(realpath "$TMP")/schema.json

--- a/test/lint/fail_draft7_defs_ref_target_fix.sh
+++ b/test/lint/fail_draft7_defs_ref_target_fix.sh
@@ -28,6 +28,7 @@ EOF
 test "$CODE" = "1" || exit 1
 
 cat << EOF > "$TMP/expected.txt"
+.
 error: Could not autofix the schema without breaking its internal references
   at file path $(realpath "$TMP")/schema.json
   at location "/allOf/0/\$ref"

--- a/test/lint/fail_lint_fix_broken_reference.sh
+++ b/test/lint/fail_lint_fix_broken_reference.sh
@@ -38,6 +38,7 @@ cd "$TMP"
 test "$CODE" = "1" || exit 1
 
 cat << EOF > "$TMP/expected.txt"
+.
 error: Could not autofix the schema without breaking its internal references
   at file path $(realpath "$TMP")/schema.json
   at location "/properties/bar/\$ref"

--- a/test/lint/fail_lint_half_unfixable.sh
+++ b/test/lint/fail_lint_half_unfixable.sh
@@ -26,6 +26,7 @@ cd "$TMP"
 test "$CODE" = "2" || exit 1
 
 cat << 'EOF' > "$TMP/expected.txt"
+..
 schema.json:1:1:
   Set a concise non-empty title at the top level of the schema to explain what the definition is about (top_level_title)
     at location ""

--- a/test/lint/pass_lint_default_fix.sh
+++ b/test/lint/pass_lint_default_fix.sh
@@ -25,6 +25,7 @@ EOF
 "$1" lint "$TMP/schema.json" --fix > "$TMP/result.txt" 2>&1
 
 cat << 'EOF' > "$TMP/output.txt"
+.
 EOF
 
 diff "$TMP/result.txt" "$TMP/output.txt"

--- a/test/lint/pass_lint_examples_fix.sh
+++ b/test/lint/pass_lint_examples_fix.sh
@@ -25,6 +25,7 @@ EOF
 "$1" lint "$TMP/schema.json" --fix > "$TMP/result.txt" 2>&1
 
 cat << 'EOF' > "$TMP/output.txt"
+.
 EOF
 
 diff "$TMP/result.txt" "$TMP/output.txt"

--- a/test/lint/pass_lint_fix_format.sh
+++ b/test/lint/pass_lint_fix_format.sh
@@ -21,6 +21,7 @@ EOF
 "$1" lint "$TMP/schema.json" --fix --format > "$TMP/output.txt" 2>&1
 
 cat << 'EOF' > "$TMP/expected_output.txt"
+.
 EOF
 diff "$TMP/output.txt" "$TMP/expected_output.txt"
 

--- a/test/lint/pass_lint_fix_format_directory.sh
+++ b/test/lint/pass_lint_fix_format_directory.sh
@@ -33,6 +33,7 @@ EOF
 "$1" lint "$TMP/schemas" --fix --format > "$TMP/output.txt" 2>&1
 
 cat << 'EOF' > "$TMP/expected_output.txt"
+.
 EOF
 diff "$TMP/output.txt" "$TMP/expected_output.txt"
 

--- a/test/lint/pass_lint_fix_format_keep_ordering.sh
+++ b/test/lint/pass_lint_fix_format_keep_ordering.sh
@@ -21,6 +21,7 @@ EOF
 "$1" lint "$TMP/schema.json" --fix --format --keep-ordering > "$TMP/output.txt" 2>&1
 
 cat << 'EOF' > "$TMP/expected_output.txt"
+.
 EOF
 diff "$TMP/output.txt" "$TMP/expected_output.txt"
 

--- a/vendor/codegen/src/ir/ir.cc
+++ b/vendor/codegen/src/ir/ir.cc
@@ -30,7 +30,8 @@ auto compile(const sourcemeta::core::JSON &input,
                         sourcemeta::core::AlterSchemaMode::Canonicalizer);
   [[maybe_unused]] const auto canonicalized{canonicalizer.apply(
       schema, walker, resolver,
-      [](const auto &, const auto, const auto, const auto &) { assert(false); },
+      [](const auto &, const auto, const auto, const auto &,
+         [[maybe_unused]] const auto applied) { assert(applied); },
       default_dialect, default_id)};
   assert(canonicalized.first);
 

--- a/vendor/core/src/core/jsonschema/include/sourcemeta/core/jsonschema_transform.h
+++ b/vendor/core/src/core/jsonschema/include/sourcemeta/core/jsonschema_transform.h
@@ -253,9 +253,10 @@ public:
   /// - The name of the rule
   /// - The message of the rule
   /// - The rule evaluation result
-  using Callback = std::function<void(const Pointer &, const std::string_view,
-                                      const std::string_view,
-                                      const SchemaTransformRule::Result &)>;
+  /// - Whether the rule is mutable (on check) or was mutated (on apply)
+  using Callback = std::function<void(
+      const Pointer &, const std::string_view, const std::string_view,
+      const SchemaTransformRule::Result &, const bool)>;
 
   /// Apply the bundle of rules to a schema
   [[nodiscard]] auto

--- a/vendor/core/src/core/jsonschema/transformer.cc
+++ b/vendor/core/src/core/jsonschema/transformer.cc
@@ -87,7 +87,8 @@ auto check_rules(
                                      exclude_keyword)};
       if (outcome.applies) {
         subschema_failed = true;
-        callback(entry_pointer, rule->name(), rule->message(), outcome);
+        callback(entry_pointer, rule->name(), rule->message(), outcome,
+                 mutates);
       }
     }
 
@@ -273,6 +274,7 @@ auto SchemaTransformer::apply(JSON &schema, const SchemaWalker &walker,
         }
 
         rule->transform(current, outcome);
+        callback(entry_pointer, rule->name(), rule->message(), outcome, true);
 
         applied = true;
 

--- a/vendor/jsonbinpack/src/compiler/compiler.cc
+++ b/vendor/jsonbinpack/src/compiler/compiler.cc
@@ -12,11 +12,9 @@
 static auto
 transformer_callback_noop(const sourcemeta::core::Pointer &,
                           const std::string_view, const std::string_view,
-                          const sourcemeta::core::SchemaTransformRule::Result &)
-    -> void {
-  // This callback should never be called, as all the transformation rules
-  // we define in this project can indeed be transformed
-  assert(false);
+                          const sourcemeta::core::SchemaTransformRule::Result &,
+                          [[maybe_unused]] const bool applied) -> void {
+  assert(applied);
 }
 
 namespace sourcemeta::jsonbinpack {


### PR DESCRIPTION
Useful for schemas that might take a while to auto-fix given their size
and/or complexity.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
