### PR TITLE
Improve `format` and `allOf` related linter rules

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,7 +1,7 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
 core https://github.com/sourcemeta/core 2ce5c318e0f9b3e84f382f6e0df8a56b7b3c46cd
 jsonbinpack https://github.com/sourcemeta/jsonbinpack 8b93f69a1270d8d05eed6bb9e106c4d6613bb257
-blaze https://github.com/sourcemeta/blaze 2624388def904ed9a4c6a7688c6e346c7c83fa04
+blaze https://github.com/sourcemeta/blaze c14f618e92ac842784dc4a8efd94717c78165afc
 mbedtls https://github.com/Mbed-TLS/mbedtls v3.6.6
 curl https://github.com/curl/curl curl-8_20_0
 nghttp2 https://github.com/nghttp2/nghttp2 v1.67.1

--- a/test/lint/pass_lint_list_exclude.sh
+++ b/test/lint/pass_lint_list_exclude.sh
@@ -268,6 +268,9 @@ unevaluated_items_default
 unevaluated_properties_default
   Setting the `unevaluatedProperties` keyword to the true schema does not add any further constraint
 
+unknown_format_prefix
+  For interoperability purposes, the JSON Schema specification advises against the use of `format` values that are not explicitly defined by the specification
+
 unknown_keywords_prefix
   Future versions of JSON Schema will refuse to evaluate unknown keywords or custom keywords from optional vocabularies that don't have an x- prefix
 
@@ -301,7 +304,7 @@ unsatisfiable_max_contains
 unsatisfiable_min_properties
   Setting `minProperties` to a number less than `required` does not add any further constraint
 
-Number of rules: 97
+Number of rules: 98
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/lint/pass_lint_list_long.sh
+++ b/test/lint/pass_lint_list_long.sh
@@ -268,6 +268,9 @@ unevaluated_items_default
 unevaluated_properties_default
   Setting the `unevaluatedProperties` keyword to the true schema does not add any further constraint
 
+unknown_format_prefix
+  For interoperability purposes, the JSON Schema specification advises against the use of `format` values that are not explicitly defined by the specification
+
 unknown_keywords_prefix
   Future versions of JSON Schema will refuse to evaluate unknown keywords or custom keywords from optional vocabularies that don't have an x- prefix
 
@@ -307,7 +310,7 @@ valid_default
 valid_examples
   Only include instances in the `examples` array that validate against the schema
 
-Number of rules: 99
+Number of rules: 100
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/lint/pass_lint_list_short.sh
+++ b/test/lint/pass_lint_list_short.sh
@@ -268,6 +268,9 @@ unevaluated_items_default
 unevaluated_properties_default
   Setting the `unevaluatedProperties` keyword to the true schema does not add any further constraint
 
+unknown_format_prefix
+  For interoperability purposes, the JSON Schema specification advises against the use of `format` values that are not explicitly defined by the specification
+
 unknown_keywords_prefix
   Future versions of JSON Schema will refuse to evaluate unknown keywords or custom keywords from optional vocabularies that don't have an x- prefix
 
@@ -307,7 +310,7 @@ valid_default
 valid_examples
   Only include instances in the `examples` array that validate against the schema
 
-Number of rules: 99
+Number of rules: 100
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/vendor/blaze/src/alterschema/alterschema.cc
+++ b/vendor/blaze/src/alterschema/alterschema.cc
@@ -265,6 +265,7 @@ auto WALK_UP_IN_PLACE_APPLICATORS(const JSON &root, const SchemaFrame &frame,
 #include "linter/top_level_title.h"
 #include "linter/unevaluated_items_default.h"
 #include "linter/unevaluated_properties_default.h"
+#include "linter/unknown_format_prefix.h"
 #include "linter/unsatisfiable_max_contains.h"
 #include "linter/unsatisfiable_min_properties.h"
 #include "linter/valid_default.h"
@@ -479,6 +480,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
     bundle.add<SimplePropertiesIdentifiers>();
     bundle.add<PortableAnchorNames>();
     bundle.add<InvalidExternalRef>();
+    bundle.add<UnknownFormatPrefix>();
     bundle.add<ValidDefault>();
     bundle.add<ValidExamples>();
   }

--- a/vendor/blaze/src/alterschema/linter/unknown_format_prefix.h
+++ b/vendor/blaze/src/alterschema/linter/unknown_format_prefix.h
@@ -1,0 +1,111 @@
+class UnknownFormatPrefix final : public SchemaTransformRule {
+public:
+  using mutates = std::true_type;
+  using reframe_after_transform = std::true_type;
+  UnknownFormatPrefix()
+      : SchemaTransformRule{
+            "unknown_format_prefix",
+            "For interoperability purposes, the JSON Schema specification "
+            "advises against the use of "
+            "`format` values that are not explicitly defined by the "
+            "specification"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::core::Vocabularies &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &,
+            const sourcemeta::core::SchemaWalker &,
+            const sourcemeta::core::SchemaResolver &) const
+      -> SchemaTransformRule::Result override {
+    ONLY_CONTINUE_IF(schema.is_object() && schema.defines("format"));
+    const auto &format_value{schema.at("format")};
+    ONLY_CONTINUE_IF(format_value.is_string());
+
+    const auto *recognized{recognized_formats_for(vocabularies)};
+    if (recognized == nullptr) {
+      return false;
+    }
+
+    if (recognized->contains(format_value.to_string())) {
+      return false;
+    }
+
+    return APPLIES_TO_KEYWORDS("format");
+  }
+
+  auto transform(sourcemeta::core::JSON &schema, const Result &) const
+      -> void override {
+    std::string prefixed_name{"x-format"};
+    while (schema.defines(prefixed_name)) {
+      prefixed_name.insert(0, "x-");
+    }
+    schema.rename("format", std::move(prefixed_name));
+  }
+
+private:
+  static auto
+  recognized_formats_for(const sourcemeta::core::Vocabularies &vocabularies)
+      -> const std::unordered_set<std::string_view> * {
+    using Known = sourcemeta::core::Vocabularies::Known;
+    if (vocabularies.contains_any(
+            {Known::JSON_Schema_Draft_3, Known::JSON_Schema_Draft_3_Hyper})) {
+      return &DRAFT_3_FORMATS;
+    }
+    if (vocabularies.contains_any(
+            {Known::JSON_Schema_Draft_4, Known::JSON_Schema_Draft_4_Hyper})) {
+      return &DRAFT_4_FORMATS;
+    }
+    if (vocabularies.contains_any(
+            {Known::JSON_Schema_Draft_6, Known::JSON_Schema_Draft_6_Hyper})) {
+      return &DRAFT_6_FORMATS;
+    }
+    if (vocabularies.contains_any(
+            {Known::JSON_Schema_Draft_7, Known::JSON_Schema_Draft_7_Hyper})) {
+      return &DRAFT_7_FORMATS;
+    }
+    if (vocabularies.contains(Known::JSON_Schema_2019_09_Format)) {
+      return &DRAFT_2019_09_FORMATS;
+    }
+    if (vocabularies.contains(Known::JSON_Schema_2020_12_Format_Annotation) ||
+        vocabularies.contains(Known::JSON_Schema_2020_12_Format_Assertion)) {
+      return &DRAFT_2020_12_FORMATS;
+    }
+    return nullptr;
+  }
+
+  static inline const std::unordered_set<std::string_view> DRAFT_3_FORMATS{
+      "date-time",  "date",  "time",     "utc-millisec", "regex",
+      "color",      "style", "phone",    "uri",          "email",
+      "ip-address", "ipv6",  "host-name"};
+  static inline const std::unordered_set<std::string_view> DRAFT_4_FORMATS{
+      "date-time", "email", "hostname", "ipv4", "ipv6", "uri"};
+  static inline const std::unordered_set<std::string_view> DRAFT_6_FORMATS{
+      "date-time", "email",         "hostname",     "ipv4",        "ipv6",
+      "uri",       "uri-reference", "uri-template", "json-pointer"};
+  static inline const std::unordered_set<std::string_view> DRAFT_7_FORMATS{
+      "date-time",     "date",         "time",          "email",
+      "idn-email",     "hostname",     "idn-hostname",  "ipv4",
+      "ipv6",          "uri",          "uri-reference", "iri",
+      "iri-reference", "uri-template", "json-pointer",  "relative-json-pointer",
+      "regex"};
+  static inline const std::unordered_set<std::string_view>
+      DRAFT_2019_09_FORMATS{
+          "date-time",    "date",          "time",
+          "duration",     "email",         "idn-email",
+          "hostname",     "idn-hostname",  "ipv4",
+          "ipv6",         "uri",           "uri-reference",
+          "iri",          "iri-reference", "uuid",
+          "uri-template", "json-pointer",  "relative-json-pointer",
+          "regex"};
+  static inline const std::unordered_set<std::string_view>
+      DRAFT_2020_12_FORMATS{
+          "date-time",    "date",          "time",
+          "duration",     "email",         "idn-email",
+          "hostname",     "idn-hostname",  "ipv4",
+          "ipv6",         "uri",           "uri-reference",
+          "iri",          "iri-reference", "uuid",
+          "uri-template", "json-pointer",  "relative-json-pointer",
+          "regex"};
+};

--- a/vendor/blaze/src/alterschema/linter/unnecessary_allof_wrapper.h
+++ b/vendor/blaze/src/alterschema/linter/unnecessary_allof_wrapper.h
@@ -27,6 +27,21 @@ public:
     ONLY_CONTINUE_IF(all_of_value && all_of_value->is_array() &&
                      !all_of_value->empty());
 
+    std::unordered_map<std::string_view, std::size_t> keyword_frequency;
+    for (const auto &entry : all_of_value->as_array()) {
+      if (!entry.is_object()) {
+        continue;
+      }
+      for (const auto &property : entry.as_object()) {
+        const auto &metadata{walker(property.first, vocabularies)};
+        if (metadata.type == SchemaKeywordType::Annotation ||
+            metadata.type == SchemaKeywordType::Comment) {
+          continue;
+        }
+        keyword_frequency[property.first]++;
+      }
+    }
+
     std::unordered_set<std::string_view> dependency_blocked;
     for (const auto &entry : schema.as_object()) {
       if ((entry.first == "unevaluatedProperties" ||
@@ -89,23 +104,27 @@ public:
         continue;
       }
 
-      for (const auto &keyword_entry : entry.as_object()) {
+      const auto try_elevate_keyword = [&](const auto &keyword_entry) -> bool {
         const auto &keyword{keyword_entry.first};
         const auto &metadata{walker(keyword, vocabularies)};
 
         if (elevated.contains(keyword) ||
             (schema.defines(keyword) &&
              schema.at(keyword) != keyword_entry.second)) {
-          continue;
+          return false;
         }
 
         if (dependency_blocked.contains(keyword)) {
-          continue;
+          return false;
+        }
+
+        if (keyword_frequency[keyword] > 1) {
+          return false;
         }
 
         if (metadata.instances.any() && parent_types.any() &&
             (metadata.instances & parent_types).none()) {
-          continue;
+          return false;
         }
 
         if (std::ranges::any_of(metadata.dependencies,
@@ -114,7 +133,7 @@ public:
                                          (schema.defines(dependency) ||
                                           elevated.contains(dependency));
                                 })) {
-          continue;
+          return false;
         }
 
         locations.push_back(Pointer{KEYWORD, index - 1, keyword});
@@ -130,6 +149,33 @@ public:
               dependency_blocked.emplace(dependency);
             }
           }
+        }
+
+        return true;
+      };
+
+      bool entry_has_non_annotation = false;
+      bool non_annotation_elevated = false;
+      for (const auto &keyword_entry : entry.as_object()) {
+        const auto &metadata{walker(keyword_entry.first, vocabularies)};
+        if (metadata.type == SchemaKeywordType::Annotation ||
+            metadata.type == SchemaKeywordType::Comment) {
+          continue;
+        }
+        entry_has_non_annotation = true;
+        if (try_elevate_keyword(keyword_entry)) {
+          non_annotation_elevated = true;
+        }
+      }
+
+      if (!entry_has_non_annotation || non_annotation_elevated) {
+        for (const auto &keyword_entry : entry.as_object()) {
+          const auto &metadata{walker(keyword_entry.first, vocabularies)};
+          if (metadata.type != SchemaKeywordType::Annotation &&
+              metadata.type != SchemaKeywordType::Comment) {
+            continue;
+          }
+          try_elevate_keyword(keyword_entry);
         }
       }
     }

--- a/vendor/blaze/src/alterschema/upgrade/upgrade_draft_3_to_draft_4.h
+++ b/vendor/blaze/src/alterschema/upgrade/upgrade_draft_3_to_draft_4.h
@@ -61,6 +61,7 @@ public:
     rewrite_divisible_by(schema);
     rewrite_required_property_booleans(schema);
     rewrite_dependencies_string_form(schema);
+    rewrite_format(schema);
 
     if (schema.defines("$schema") && schema.at("$schema").is_string() &&
         schema.at("$schema").to_string() == DRAFT_3_URL) {
@@ -141,7 +142,25 @@ private:
       }
     }
 
+    if (has_renamable_draft_3_format(subschema)) {
+      return true;
+    }
+
     return false;
+  }
+
+  static auto
+  has_renamable_draft_3_format(const sourcemeta::core::JSON &subschema)
+      -> bool {
+    if (!subschema.is_object()) {
+      return false;
+    }
+    const auto *format_value{subschema.try_at("format")};
+    if (format_value == nullptr || !format_value->is_string()) {
+      return false;
+    }
+    const auto &name{format_value->to_string()};
+    return name == "host-name" || name == "ip-address";
   }
 
   static auto rewrite_type_any(sourcemeta::core::JSON &schema) -> void {
@@ -377,6 +396,22 @@ private:
       auto array{sourcemeta::core::JSON::make_array()};
       array.push_back(sourcemeta::core::JSON{value});
       dependencies.assign(key, std::move(array));
+    }
+  }
+
+  static auto rewrite_format(sourcemeta::core::JSON &schema) -> void {
+    if (!schema.defines("format")) {
+      return;
+    }
+    auto &format_value{schema.at("format")};
+    if (!format_value.is_string()) {
+      return;
+    }
+    const auto &name{format_value.to_string()};
+    if (name == "host-name") {
+      schema.assign("format", sourcemeta::core::JSON{"hostname"});
+    } else if (name == "ip-address") {
+      schema.assign("format", sourcemeta::core::JSON{"ipv4"});
     }
   }
 


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/jsonschema/issues/753
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
