### PR TITLE
Fix `upgrade` not correctly handling `$vocabulary` in 2019-09 to 2020-12

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,7 +1,7 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
 core https://github.com/sourcemeta/core 5d187a796444fef1b5e044c659800085a4be7ef4
 jsonbinpack https://github.com/sourcemeta/jsonbinpack 40293a182cabf15678ca0b59cddaf108e7862787
-blaze https://github.com/sourcemeta/blaze 5d9f3d375498748a8e4f43da698cb5a7fb166f1e
+blaze https://github.com/sourcemeta/blaze 902fae6ebbb2afba113a57934c82dfdd661d8128
 mbedtls https://github.com/Mbed-TLS/mbedtls v3.6.6
 curl https://github.com/curl/curl curl-8_20_0
 nghttp2 https://github.com/nghttp2/nghttp2 v1.67.1

--- a/vendor/blaze/ports/javascript/README.md
+++ b/vendor/blaze/ports/javascript/README.md
@@ -133,3 +133,7 @@ Numeric keywords like `multipleOf` that depend on exact decimal arithmetic may
 produce incorrect results for real values that lose precision during parsing.
 The TC39 [Decimal proposal](https://github.com/tc39/proposal-decimal) (Stage 2)
 aims to address this in the future.
+
+**No Format Assertion vocabulary support.** While the C++ implementation of
+Blaze fully implements the Format Assertion vocabulary, no such option exists
+for JavaScript yet. Contributions in this area are welcomed.

--- a/vendor/blaze/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
+++ b/vendor/blaze/src/alterschema/upgrade/upgrade_2019_09_to_2020_12.h
@@ -156,6 +156,8 @@ public:
       }
     }
 
+    rewrite_vocabulary(schema);
+
     if (schema.defines("$schema") && schema.at("$schema").is_string() &&
         schema.at("$schema").to_string() == DRAFT_2019_09_URL) {
       schema.assign("$schema", sourcemeta::core::JSON{DRAFT_2020_12_URL});
@@ -186,6 +188,89 @@ private:
       "https://json-schema.org/draft/2019-09/schema"};
   static constexpr std::string_view DRAFT_2020_12_URL{
       "https://json-schema.org/draft/2020-12/schema"};
+  static constexpr std::string_view APPLICATOR_2019_09_URI{
+      "https://json-schema.org/draft/2019-09/vocab/applicator"};
+  static constexpr std::string_view APPLICATOR_2020_12_URI{
+      "https://json-schema.org/draft/2020-12/vocab/applicator"};
+  static constexpr std::string_view UNEVALUATED_2020_12_URI{
+      "https://json-schema.org/draft/2020-12/vocab/unevaluated"};
+
+  static inline const std::unordered_map<std::string, std::string>
+      VOCAB_URI_MAP_2019_09_TO_2020_12{
+          {"https://json-schema.org/draft/2019-09/vocab/core",
+           "https://json-schema.org/draft/2020-12/vocab/core"},
+          {"https://json-schema.org/draft/2019-09/vocab/applicator",
+           "https://json-schema.org/draft/2020-12/vocab/applicator"},
+          {"https://json-schema.org/draft/2019-09/vocab/validation",
+           "https://json-schema.org/draft/2020-12/vocab/validation"},
+          {"https://json-schema.org/draft/2019-09/vocab/meta-data",
+           "https://json-schema.org/draft/2020-12/vocab/meta-data"},
+          {"https://json-schema.org/draft/2019-09/vocab/format",
+           "https://json-schema.org/draft/2020-12/vocab/format-annotation"},
+          {"https://json-schema.org/draft/2019-09/vocab/content",
+           "https://json-schema.org/draft/2020-12/vocab/content"}};
+
+  static auto
+  vocabulary_has_mappable_uri(const sourcemeta::core::JSON &subschema) -> bool {
+    if (!subschema.is_object() || !subschema.defines("$vocabulary") ||
+        !subschema.at("$vocabulary").is_object()) {
+      return false;
+    }
+    for (const auto &entry : subschema.at("$vocabulary").as_object()) {
+      if (VOCAB_URI_MAP_2019_09_TO_2020_12.contains(entry.first)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static auto rewrite_vocabulary(sourcemeta::core::JSON &schema) -> void {
+    if (!schema.is_object() || !schema.defines("$vocabulary") ||
+        !schema.at("$vocabulary").is_object()) {
+      return;
+    }
+
+    std::unordered_set<std::string> source_keys;
+    std::optional<sourcemeta::core::JSON> applicator_2019_09_value;
+    for (const auto &entry : schema.at("$vocabulary").as_object()) {
+      source_keys.insert(entry.first);
+      if (entry.first == APPLICATOR_2019_09_URI) {
+        applicator_2019_09_value = entry.second;
+      }
+    }
+
+    const bool unevaluated_already_present{
+        source_keys.contains(std::string{UNEVALUATED_2020_12_URI})};
+    const bool should_inline_unevaluated{applicator_2019_09_value.has_value() &&
+                                         !unevaluated_already_present};
+
+    auto fresh{sourcemeta::core::JSON::make_object()};
+
+    for (const auto &entry : schema.at("$vocabulary").as_object()) {
+      const auto iter{VOCAB_URI_MAP_2019_09_TO_2020_12.find(entry.first)};
+      if (iter == VOCAB_URI_MAP_2019_09_TO_2020_12.cend()) {
+        fresh.assign(entry.first, entry.second);
+        if (entry.first == APPLICATOR_2020_12_URI &&
+            should_inline_unevaluated) {
+          fresh.assign(std::string{UNEVALUATED_2020_12_URI},
+                       applicator_2019_09_value.value());
+        }
+        continue;
+      }
+
+      if (source_keys.contains(iter->second)) {
+        continue;
+      }
+
+      fresh.assign(iter->second, entry.second);
+
+      if (entry.first == APPLICATOR_2019_09_URI && should_inline_unevaluated) {
+        fresh.assign(std::string{UNEVALUATED_2020_12_URI}, entry.second);
+      }
+    }
+
+    schema.at("$vocabulary").into(std::move(fresh));
+  }
 
   struct AnchorRename {
     sourcemeta::core::Pointer subschema_pointer;
@@ -311,7 +396,8 @@ private:
       return false;
     }
     if (!subschema.defines_any({"$schema", "$recursiveAnchor", "$recursiveRef",
-                                "items", "additionalItems", "contains"})) {
+                                "items", "additionalItems", "contains",
+                                "$vocabulary"})) {
       return false;
     }
     if (subschema.defines("$schema") && subschema.at("$schema").is_string() &&
@@ -327,6 +413,9 @@ private:
     }
     if (subschema.defines("contains") &&
         !location_inside_contains_wrapper(location)) {
+      return true;
+    }
+    if (vocabulary_has_mappable_uri(subschema)) {
       return true;
     }
     return false;

--- a/vendor/blaze/src/foundation/foundation.cc
+++ b/vendor/blaze/src/foundation/foundation.cc
@@ -512,10 +512,16 @@ auto sourcemeta::blaze::parse_vocabularies(
     return std::nullopt;
   }
 
-  assert(vocabulary_entry->is_object());
+  if (!vocabulary_entry->is_object()) {
+    return std::nullopt;
+  }
+
   sourcemeta::blaze::Vocabularies result;
   for (const auto &entry : vocabulary_entry->as_object()) {
-    assert(entry.second.is_boolean());
+    if (!entry.second.is_boolean()) {
+      return std::nullopt;
+    }
+
     result.insert(entry.first, entry.second.to_boolean());
   }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
