### PR TITLE
Properly blaming BCP 47 for language value reqs

### DIFF
--- a/docs/rdf.markdown
+++ b/docs/rdf.markdown
@@ -86,12 +86,14 @@ lint rules that catch more of these mistakes statically at design time, where
 they belong, instead of paying for the checks on every promotion.
 
 > [!NOTE]
-> As a deliberate deviation from JSON-LD 1.1, language tags must be written in
-> canonical BCP 47 form, as `x-jsonld-language` values, as the map keys of an
-> `@language` container in instance data, and as `@language` members of
+> As a deliberate deviation from BCP 47's lenient approach to canonical identifiers
+> (which JSON-LD 1.1 inherits), the language tags must be written in
+> strictly canonical form in `x-jsonld-language` values as the map keys of an
+> `@language` container in instance data and as `@language` members of
 > `x-jsonld-constants` literals. For example, `en-US` is accepted while
-> `en-us` is rejected. This keeps language tag equality a plain cheap string
-> comparison everywhere in the engine.
+> `en-us` is rejected (as a departure from BCP 47's lenient requirements).
+>  This keeps language tag equality a plain cheap string comparison everywhere
+> in the engine.
 
 The variables of an `x-jsonld-self` URI template are matched verbatim against
 instance property names, so a variable like `{+meta.slug}` binds a property


### PR DESCRIPTION
Clarify language tag requirements for JSON-LD deviations.

BCP 47 is the accommodating spec here. JSON-LD 1.1 just inherits that liberality.

As Gemini summed it up...
> **BCP 47 says:** "Any case is fine, but here is a preferred way to look at it.
> **"JSON-LD 1.1 says:** "If BCP 47 says it's fine, we accept it.
> **"JSON Shema + RDF says:** "We do not accept any case; we strictly require the canonical casing."

It's the right approach for a surface syntax enforcing system like JSON Schema (assuming the dev wants it that strict), but not strictly (heh) a JSON-LD "problem" as it inherits from BCP 47's term/string liberality.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

