### PR TITLE
Speed up schema compilation in the `test` command

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
 core https://github.com/sourcemeta/core 036ae97b31bf133fa5c19ad0192bc1eb008f1b0b
 jsonbinpack https://github.com/sourcemeta/jsonbinpack 4b6ce4281663f128a37f0d16bf44a98083d744cc
-blaze https://github.com/sourcemeta/blaze 31d3723e2bfac22acbaaae23f1f9d02e75ce4c00
+blaze https://github.com/sourcemeta/blaze 692cb6487ed3390d042c85ce451917d23c5010a7
 ctrf https://github.com/ctrf-io/ctrf 93ea827d951390190171d37443bff169cf47c808

--- a/src/command_test.cc
+++ b/src/command_test.cc
@@ -249,9 +249,8 @@ auto run_suite_as_text(const sourcemeta::core::Options &options,
               std::distance(test_suite.targets.cbegin(),
                             std::find(test_suite.targets.cbegin(),
                                       test_suite.targets.cend(), target)))};
-          test_suite.evaluator.validate(
-              test_suite.schemas_exhaustive[target_index], test_case.data,
-              std::ref(output));
+          test_suite.evaluator.validate(test_suite.exhaustive(target_index),
+                                        test_case.data, std::ref(output));
 
           if (!verbose) {
             stream << "\n";
@@ -451,9 +450,8 @@ auto run_suite_as_ctrf(const sourcemeta::core::Options &options,
                 std::distance(test_suite.targets.cbegin(),
                               std::find(test_suite.targets.cbegin(),
                                         test_suite.targets.cend(), target)))};
-            test_suite.evaluator.validate(
-                test_suite.schemas_exhaustive[target_index], test_case.data,
-                std::ref(output));
+            test_suite.evaluator.validate(test_suite.exhaustive(target_index),
+                                          test_case.data, std::ref(output));
             sourcemeta::jsonschema::print(output, test_case.tracker,
                                           trace_stream);
             test_object.assign("trace",

--- a/test/bundle/pass_ref_in_bundled_resolves_against_id.sh
+++ b/test/bundle/pass_ref_in_bundled_resolves_against_id.sh
@@ -37,6 +37,7 @@ cat << EOF > "$TMP/expected.json"
   "\$ref": "https://example.com/schemas/parent",
   "\$defs": {
     "https://example.com/schemas/child": {
+      "\$schema": "https://json-schema.org/draft/2020-12/schema",
       "\$id": "https://example.com/schemas/child",
       "type": "string"
     },

--- a/vendor/blaze/src/bundle/bundle.cc
+++ b/vendor/blaze/src/bundle/bundle.cc
@@ -11,7 +11,7 @@
 #include <tuple>         // std::tuple
 #include <unordered_map> // std::unordered_map
 #include <unordered_set> // std::unordered_set
-#include <utility>       // std::move
+#include <utility>       // std::move, std::pair
 #include <vector>        // std::vector
 
 namespace {
@@ -166,6 +166,8 @@ auto elevate_embedded_resources(
   }
 
   auto &defs{remote.at(keyword_string)};
+  const auto remote_dialect_uri{
+      sourcemeta::blaze::dialect(remote, default_dialect)};
 
   // Navigate to the root container once, as it doesn't change per entry
   const sourcemeta::core::JSON *root_container{&root};
@@ -180,7 +182,7 @@ auto elevate_embedded_resources(
     root_container = &root_container->at(token.to_property());
   }
 
-  std::vector<sourcemeta::core::JSON::String> to_extract;
+  std::vector<std::pair<sourcemeta::core::JSON::String, bool>> to_extract;
   std::vector<sourcemeta::core::JSON::String> to_remove;
   for (const auto &entry : defs.as_object()) {
     const auto &key{entry.first};
@@ -196,6 +198,7 @@ auto elevate_embedded_resources(
     }
 
     const sourcemeta::core::JSON::String identifier_string{identifier};
+    const auto defines_dialect{value.defines("$schema")};
     if (bundled.contains(identifier_string)) {
       if (container_exists && root_container->is_object()) {
         for (const auto &root_entry : root_container->as_object()) {
@@ -214,9 +217,23 @@ auto elevate_embedded_resources(
             continue;
           }
 
-          if (root_entry.second != value) {
-            throw sourcemeta::blaze::SchemaError(
-                "Conflicting embedded resources with the same identifier");
+          if (defines_dialect) {
+            if (root_entry.second != value) {
+              throw sourcemeta::blaze::SchemaError(
+                  "Conflicting embedded resources with the same identifier");
+            }
+          } else {
+            // The stored copy of the resource got its dialect stamped on
+            // extraction, so compare against a candidate that is stamped in
+            // the same way
+            auto candidate{value};
+            candidate.assign("$schema",
+                             sourcemeta::core::JSON{sourcemeta::blaze::dialect(
+                                 value, remote_dialect_uri)});
+            if (root_entry.second != candidate) {
+              throw sourcemeta::blaze::SchemaError(
+                  "Conflicting embedded resources with the same identifier");
+            }
           }
 
           break;
@@ -225,14 +242,22 @@ auto elevate_embedded_resources(
 
       to_remove.emplace_back(key);
     } else {
-      to_extract.emplace_back(key);
+      to_extract.emplace_back(key, !defines_dialect);
       bundled.emplace(identifier_string, identifier_string);
     }
   }
 
-  for (const auto &key : to_extract) {
+  for (const auto &[key, needs_dialect] : to_extract) {
     auto value{std::move(defs.at(key))};
     defs.erase(key);
+    // Otherwise the elevated resource would be re-interpreted under the
+    // dialect of the schema it gets embedded into, which can differ from
+    // the dialect it inherited from the remote it was elevated out of
+    if (needs_dialect) {
+      value.assign("$schema", sourcemeta::core::JSON{sourcemeta::blaze::dialect(
+                                  value, remote_dialect_uri)});
+    }
+
     embed_schema(root, container, key, std::move(value));
   }
 

--- a/vendor/blaze/src/test/include/sourcemeta/blaze/test.h
+++ b/vendor/blaze/src/test/include/sourcemeta/blaze/test.h
@@ -118,10 +118,6 @@ struct SOURCEMETA_BLAZE_TEST_EXPORT TestSuite {
   std::vector<sourcemeta::core::JSON::String> targets;
   /// The list of test cases in the suite
   std::vector<TestCase> tests;
-  /// The compiled schema templates for fast validation
-  std::vector<Template> schemas_fast;
-  /// The compiled schema templates for exhaustive validation
-  std::vector<Template> schemas_exhaustive;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)
 #endif
@@ -134,6 +130,14 @@ struct SOURCEMETA_BLAZE_TEST_EXPORT TestSuite {
       const sourcemeta::core::JSON::String &target, std::size_t index,
       std::size_t total, const TestCase &test_case, const TestOutcome &outcome,
       TestTimestamp start, TestTimestamp end)>;
+
+  /// The compiled schema template for fast validation of the given target
+  [[nodiscard]] auto fast(std::size_t target_index) const -> const Template &;
+
+  /// The compiled schema template for exhaustive validation of the given
+  /// target, compiled on the first request and cached from then on. A test
+  /// suite must not be shared across threads
+  auto exhaustive(std::size_t target_index) -> const Template &;
 
   /// Run all test cases in the suite, invoking the callback for each.
   /// For example:
@@ -231,6 +235,26 @@ struct SOURCEMETA_BLAZE_TEST_EXPORT TestSuite {
         const sourcemeta::blaze::SchemaWalker &walker, const Compiler &compiler,
         std::string_view default_dialect = "", std::string_view default_id = "",
         const std::optional<Tweaks> &tweaks = std::nullopt) -> TestSuite;
+
+private:
+  [[nodiscard]] auto compile_target(std::size_t target_index, Mode mode) const
+      -> Template;
+
+#if defined(_MSC_VER)
+#pragma warning(disable : 4251)
+#endif
+  std::vector<Template> schemas_fast;
+  std::vector<std::optional<Template>> schemas_exhaustive;
+  SchemaResolver schema_resolver;
+  SchemaWalker walker;
+  Compiler compiler;
+  sourcemeta::core::JSON::String default_dialect;
+  sourcemeta::core::JSON::String default_id;
+  std::optional<Tweaks> tweaks_fast;
+  std::optional<Tweaks> tweaks_exhaustive;
+#if defined(_MSC_VER)
+#pragma warning(default : 4251)
+#endif
 };
 
 } // namespace sourcemeta::blaze

--- a/vendor/blaze/src/test/test_parser.cc
+++ b/vendor/blaze/src/test/test_parser.cc
@@ -208,45 +208,73 @@ auto TestSuite::parse(const sourcemeta::core::JSON &document,
         return test_case.rdf.has_value();
       })};
 
-  auto tweaks_fast{tweaks};
+  test_suite.tweaks_fast = tweaks;
+  test_suite.tweaks_exhaustive = tweaks;
   if (with_rdf) {
-    if (!tweaks_fast.has_value()) {
-      tweaks_fast.emplace();
+    if (!test_suite.tweaks_fast.has_value()) {
+      test_suite.tweaks_fast.emplace();
     }
 
-    if (!tweaks_fast.value().annotations.has_value()) {
-      tweaks_fast.value().annotations.emplace();
+    if (!test_suite.tweaks_fast.value().annotations.has_value()) {
+      test_suite.tweaks_fast.value().annotations.emplace();
     }
 
-    tweaks_fast.value().annotations.value().insert(JSONLD_KEYWORDS.cbegin(),
-                                                   JSONLD_KEYWORDS.cend());
+    test_suite.tweaks_fast.value().annotations.value().insert(
+        JSONLD_KEYWORDS.cbegin(), JSONLD_KEYWORDS.cend());
   }
 
+  test_suite.schema_resolver = schema_resolver;
+  test_suite.walker = walker;
+  test_suite.compiler = compiler;
+  test_suite.default_dialect = default_dialect;
+  test_suite.default_id = default_id;
+
   test_suite.schemas_fast.reserve(test_suite.targets.size());
-  test_suite.schemas_exhaustive.reserve(test_suite.targets.size());
+  test_suite.schemas_exhaustive.resize(test_suite.targets.size());
 
-  for (const auto &target : test_suite.targets) {
-    const auto target_schema{wrap_identifier(target)};
-
-    try {
-      test_suite.schemas_fast.push_back(compile(
-          target_schema, walker, schema_resolver, compiler,
-          Mode::FastValidation, default_dialect, default_id, "", tweaks_fast));
-      test_suite.schemas_exhaustive.push_back(
-          compile(target_schema, walker, schema_resolver, compiler,
-                  Mode::Exhaustive, default_dialect, default_id, "", tweaks));
-    } catch (const sourcemeta::blaze::SchemaReferenceError &error) {
-      if (error.location() == sourcemeta::core::Pointer{"$ref"} &&
-          error.identifier() == target) {
-        throw sourcemeta::blaze::SchemaResolutionError{
-            target, "Could not resolve schema under test"};
-      }
-
-      throw;
-    }
+  for (std::size_t target_index = 0; target_index < test_suite.targets.size();
+       ++target_index) {
+    test_suite.schemas_fast.push_back(
+        test_suite.compile_target(target_index, Mode::FastValidation));
   }
 
   return test_suite;
+}
+
+auto TestSuite::compile_target(const std::size_t target_index,
+                               const Mode mode) const -> Template {
+  const auto &target{this->targets[target_index]};
+
+  try {
+    return compile(wrap_identifier(target), this->walker, this->schema_resolver,
+                   this->compiler, mode, this->default_dialect,
+                   this->default_id, "",
+                   mode == Mode::FastValidation ? this->tweaks_fast
+                                                : this->tweaks_exhaustive);
+  } catch (const sourcemeta::blaze::SchemaReferenceError &error) {
+    if (error.location() == sourcemeta::core::Pointer{"$ref"} &&
+        error.identifier() == target) {
+      throw sourcemeta::blaze::SchemaResolutionError{
+          target, "Could not resolve schema under test"};
+    }
+
+    throw;
+  }
+}
+
+auto TestSuite::fast(const std::size_t target_index) const -> const Template & {
+  assert(target_index < this->schemas_fast.size());
+  return this->schemas_fast[target_index];
+}
+
+auto TestSuite::exhaustive(const std::size_t target_index) -> const Template & {
+  assert(target_index < this->schemas_exhaustive.size());
+  auto &schema_exhaustive{this->schemas_exhaustive[target_index]};
+  if (!schema_exhaustive.has_value()) {
+    schema_exhaustive = this->compile_target(target_index, Mode::Exhaustive);
+  }
+
+  return schema_exhaustive.value();
 }
 
 } // namespace sourcemeta::blaze

--- a/vendor/blaze/src/test/test_runner.cc
+++ b/vendor/blaze/src/test/test_runner.cc
@@ -57,7 +57,7 @@ auto TestSuite::run(const Callback &callback) -> Result {
   for (std::size_t target_index = 0; target_index < this->targets.size();
        ++target_index) {
     const auto &target = this->targets[target_index];
-    const auto &schema_fast = this->schemas_fast[target_index];
+    const auto &schema_fast = this->fast(target_index);
     for (const auto &test_case : this->tests) {
       const auto start{std::chrono::steady_clock::now()};
       const auto outcome{


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

