### PR TITLE
Fix some subtle JSON and YAML CLRF parsing issues on Windows

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
 vendorpull https://github.com/sourcemeta/vendorpull 1dcbac42809cf87cb5b045106b863e17ad84ba02
-core https://github.com/sourcemeta/core fc389c728f75e4b18dd24d68cd85f7cc55a3d001
+core https://github.com/sourcemeta/core f0936adfc8a763b0fc31313816ee44ba8a7b4ad5
 jsonbinpack https://github.com/sourcemeta/jsonbinpack 4b6ce4281663f128a37f0d16bf44a98083d744cc
 blaze https://github.com/sourcemeta/blaze 692cb6487ed3390d042c85ce451917d23c5010a7
 ctrf https://github.com/ctrf-io/ctrf 93ea827d951390190171d37443bff169cf47c808

--- a/vendor/core/src/core/json/json.cc
+++ b/vendor/core/src/core/json/json.cc
@@ -128,11 +128,8 @@ auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
   const char *cursor{input.data()};
   const char *end{input.data() + input.size()};
   auto result{internal_parse_json(cursor, end, line, column, true)};
-  if (start_position != static_cast<std::streampos>(-1)) {
-    const auto consumed{static_cast<std::streamoff>(cursor - input.data())};
-    stream.clear();
-    stream.seekg(start_position + consumed);
-  }
+  resume_stream(stream, start_position,
+                static_cast<std::streamsize>(cursor - input.data()));
 
   return result;
 }
@@ -157,11 +154,8 @@ auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream)
   std::uint64_t line{1};
   std::uint64_t column{0};
   auto result{internal_parse_json(cursor, end, line, column, false)};
-  if (start_position != static_cast<std::streampos>(-1)) {
-    const auto consumed{static_cast<std::streamoff>(cursor - input.data())};
-    stream.clear();
-    stream.seekg(start_position + consumed);
-  }
+  resume_stream(stream, start_position,
+                static_cast<std::streamsize>(cursor - input.data()));
   return result;
 }
 
@@ -217,11 +211,8 @@ auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
   const char *cursor{input.data()};
   const char *end{input.data() + input.size()};
   internal_parse_json<true>(cursor, end, line, column, callback, true, output);
-  if (start_position != static_cast<std::streampos>(-1)) {
-    const auto consumed{static_cast<std::streamoff>(cursor - input.data())};
-    stream.clear();
-    stream.seekg(start_position + consumed);
-  }
+  resume_stream(stream, start_position,
+                static_cast<std::streamsize>(cursor - input.data()));
 }
 
 auto parse_json(
@@ -244,11 +235,8 @@ auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
   std::uint64_t line{1};
   std::uint64_t column{0};
   internal_parse_json<true>(cursor, end, line, column, callback, false, output);
-  if (start_position != static_cast<std::streampos>(-1)) {
-    const auto consumed{static_cast<std::streamoff>(cursor - input.data())};
-    stream.clear();
-    stream.seekg(start_position + consumed);
-  }
+  resume_stream(stream, start_position,
+                static_cast<std::streamsize>(cursor - input.data()));
 }
 
 auto parse_json(

--- a/vendor/core/src/core/yaml/yaml.cc
+++ b/vendor/core/src/core/yaml/yaml.cc
@@ -19,11 +19,10 @@ auto parse_yaml(std::basic_istream<JSON::Char, JSON::CharTraits> &stream)
 
   // The parser position is relative to the input after any byte order mark has
   // been stripped, so the mark is added back to resume the stream at the right
-  // byte
-  const auto consumed{static_cast<std::streamoff>(lexer.bom_length()) +
-                      static_cast<std::streamoff>(parser.position())};
-  stream.clear();
-  stream.seekg(start_pos + consumed);
+  // character
+  resume_stream(stream, start_pos,
+                static_cast<std::streamsize>(lexer.bom_length()) +
+                    static_cast<std::streamsize>(parser.position()));
 
   return result;
 }
@@ -62,11 +61,10 @@ auto parse_yaml(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
 
   // The parser position is relative to the input after any byte order mark has
   // been stripped, so the mark is added back to resume the stream at the right
-  // byte
-  const auto consumed{static_cast<std::streamoff>(lexer.bom_length()) +
-                      static_cast<std::streamoff>(parser.position())};
-  stream.clear();
-  stream.seekg(start_pos + consumed);
+  // character
+  resume_stream(stream, start_pos,
+                static_cast<std::streamsize>(lexer.bom_length()) +
+                    static_cast<std::streamsize>(parser.position()));
 }
 
 auto parse_yaml(const JSON::String &input, JSON &output,

--- a/vendor/core/src/lang/io/include/sourcemeta/core/io.h
+++ b/vendor/core/src/lang/io/include/sourcemeta/core/io.h
@@ -14,17 +14,18 @@
 #include <sourcemeta/core/io_temporary.h>
 // NOLINTEND(misc-include-cleaner)
 
-#include <cstddef>      // std::byte
-#include <filesystem>   // std::filesystem
-#include <fstream>      // std::basic_ifstream
-#include <functional>   // std::function
-#include <iostream>     // std::cin
-#include <istream>      // std::basic_istream
-#include <limits>       // std::numeric_limits
-#include <ostream>      // std::ostream
-#include <span>         // std::span
-#include <sstream>      // std::basic_ostringstream
-#include <string>       // std::basic_string, std::char_traits, std::string
+#include <cstddef>    // std::byte
+#include <filesystem> // std::filesystem
+#include <fstream>    // std::basic_ifstream
+#include <functional> // std::function
+#include <ios>      // std::ios, std::streamoff, std::streampos, std::streamsize
+#include <iostream> // std::cin
+#include <istream>  // std::basic_istream
+#include <limits>   // std::numeric_limits
+#include <ostream>  // std::ostream
+#include <span>     // std::span
+#include <sstream>  // std::basic_ostringstream
+#include <string>   // std::basic_string, std::char_traits, std::string
 #include <string_view>  // std::string_view
 #include <system_error> // std::error_code
 
@@ -120,7 +121,8 @@ auto strip_path_prefix(const std::filesystem::path &path,
 
 /// @ingroup io
 ///
-/// A convenience function to open a stream from a file. For example:
+/// A convenience function to open a stream from a file in binary mode, so that
+/// its positions are byte offsets on every platform. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/io.h>
@@ -137,7 +139,10 @@ auto read_file(const std::filesystem::path &path)
   }
 
   const auto canonical_path{sourcemeta::core::canonical(path)};
-  std::basic_ifstream<CharT, Traits> stream{canonical_path};
+  // Text mode translates line endings on some platforms, which desynchronises
+  // character offsets from byte offsets and makes the stream impossible to
+  // reposition by arithmetic
+  std::basic_ifstream<CharT, Traits> stream{canonical_path, std::ios::binary};
   if (!stream.is_open()) {
     throw IOFilePermissionError{canonical_path};
   }
@@ -181,6 +186,35 @@ auto read_to_string(std::basic_istream<CharT, Traits> &stream)
   std::basic_ostringstream<CharT, Traits> buffer;
   buffer << stream.rdbuf();
   return buffer.str();
+}
+
+/// @ingroup io
+///
+/// Position an input stream a given number of characters after a position it
+/// previously reported, leaving a stream that could not report one untouched.
+/// The stream must address its contents in bytes, as one opened in binary mode
+/// does. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/io.h>
+/// #include <sstream>
+/// #include <cassert>
+///
+/// std::istringstream stream{"foobar"};
+/// const auto start{stream.tellg()};
+/// sourcemeta::core::resume_stream(stream, start, 3);
+/// assert(stream.peek() == 'b');
+/// ```
+template <typename CharT = char, typename Traits = std::char_traits<CharT>>
+auto resume_stream(std::basic_istream<CharT, Traits> &stream,
+                   const std::streampos start, const std::streamsize count)
+    -> void {
+  if (start == static_cast<std::streampos>(-1)) {
+    return;
+  }
+
+  stream.clear();
+  stream.seekg(start + static_cast<std::streamoff>(count));
 }
 
 /// @ingroup io


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

