### PR TITLE
Replace the stdout extraction idiom with an EXTRACT command

### DIFF
--- a/scripts/clitest.py
+++ b/scripts/clitest.py
@@ -12,7 +12,7 @@ containing spaces or a regular expression is single quoted.
     COMPARE <actual> AGAINST <expected>
     REPLACE <pattern> WITH <replacement> IN <path>
     DROP LINES MATCHING <pattern> IN <path>
-    KEEP LINES MATCHING <pattern> IN <path>
+    EXTRACT STDOUT FROM <observation> INTO <destination>
     SORT <path>
     COPY <source> TO <destination>
     TREE <directory> INTO <destination>
@@ -266,7 +266,7 @@ class Interpreter:
             if len(operands) != 5 or operands[0] != "LINES" \
                     or operands[1] != "MATCHING" or operands[3] != "IN":
                 raise TestFailure(
-                    line_number, f"usage: {keyword} LINES MATCHING <regex> IN <file>")
+                    line_number, "usage: DROP LINES MATCHING <regex> IN <file>")
             pattern, replacement, name = operands[2], None, operands[4]
 
         path = self.resolve(name, line_number)
@@ -278,10 +278,9 @@ class Interpreter:
             content = expression.sub(
                 self.expand(replacement, line_number).replace("\\", "\\\\"), content)
         else:
-            keep = keyword == "KEEP"
             content = "".join(
                 line for line in content.splitlines(keepends=True)
-                if bool(expression.search(line)) == keep)
+                if not expression.search(line))
         self.write(path, content)
 
     def command_tree(self, operands, line_number):
@@ -329,6 +328,22 @@ class Interpreter:
             raise TestFailure(line_number, f"{name} is reserved and cannot be set")
         with open(self.resolve(operands[1], line_number), "rb") as handle:
             self.environment[name] = hashlib.sha256(handle.read()).hexdigest()
+
+    def command_extract(self, operands, line_number):
+        if len(operands) != 5 or operands[0] != "STDOUT" \
+                or operands[1] != "FROM" or operands[3] != "INTO":
+            raise TestFailure(
+                line_number,
+                "usage: EXTRACT STDOUT FROM <observation> INTO <destination>")
+        content = self.read(self.resolve(operands[2], line_number), line_number)
+        extracted = []
+        for line in content.splitlines():
+            if line == "1>":
+                extracted.append("")
+            elif line.startswith("1> "):
+                extracted.append(line[len("1> "):])
+        self.write(self.resolve(operands[4], line_number),
+                   "".join(line + "\n" for line in extracted))
 
     def command_sort(self, operands, line_number):
         if len(operands) != 1:
@@ -482,6 +497,9 @@ def check(statements):
         elif statement.keyword == "CHECKSUM" and len(operands) == 4:
             definitions.append((position, operands[3], statement.number))
             collect(consumed, [operands[1]])
+        elif statement.keyword == "EXTRACT" and len(operands) == 5:
+            record(artifacts, operands[4], (statement.number, "EXTRACT"))
+            collect(consumed, [operands[2]])
         elif statement.keyword == "STAT" and len(operands) == 4:
             record(artifacts, operands[3], (statement.number, "STAT"))
             collect(consumed, [operands[1]])
@@ -557,7 +575,7 @@ def run_script(path, binary, environment):
                 interpreter.command_compare(rest, number)
             elif keyword == "ENV":
                 interpreter.command_env(rest, number)
-            elif keyword in ("REPLACE", "DROP", "KEEP"):
+            elif keyword in ("REPLACE", "DROP"):
                 interpreter.command_filter(keyword, rest, number)
             elif keyword == "TREE":
                 interpreter.command_tree(rest, number)
@@ -567,6 +585,8 @@ def run_script(path, binary, environment):
                 interpreter.command_compress(rest, number)
             elif keyword == "CHECKSUM":
                 interpreter.command_checksum(rest, number)
+            elif keyword == "EXTRACT":
+                interpreter.command_extract(rest, number)
             elif keyword == "SORT":
                 interpreter.command_sort(rest, number)
             elif keyword == "STAT":

--- a/test/bundle/pass_bigint.clitest
+++ b/test/bundle/pass_bigint.clitest
@@ -24,9 +24,7 @@ EOF
 
 RUN bundle schema.json --resolve nested.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_boolean_schema_default_dialect.clitest
+++ b/test/bundle/pass_boolean_schema_default_dialect.clitest
@@ -7,9 +7,7 @@ EOF
 
 RUN bundle schema.json --default-dialect https://json-schema.org/draft/2020-12/schema STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> true

--- a/test/bundle/pass_bundled_metaschema.clitest
+++ b/test/bundle/pass_bundled_metaschema.clitest
@@ -22,9 +22,7 @@ EOF
 
 RUN bundle schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_config_ignore.clitest
+++ b/test/bundle/pass_config_ignore.clitest
@@ -41,9 +41,7 @@ EOF
 
 RUN bundle schema.json --resolve schemas STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_into_resolve_directory.clitest
+++ b/test/bundle/pass_into_resolve_directory.clitest
@@ -28,9 +28,7 @@ EOF
 
 RUN bundle schema.json --resolve schemas STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_resolve_directory.clitest
+++ b/test/bundle/pass_resolve_directory.clitest
@@ -23,9 +23,7 @@ EOF
 
 RUN bundle schema.json --resolve schemas STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_resolve_metaschema.clitest
+++ b/test/bundle/pass_resolve_metaschema.clitest
@@ -40,9 +40,7 @@ EOF
 
 RUN bundle schema.json --resolve schemas STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_resolve_no_identifier.clitest
+++ b/test/bundle/pass_resolve_no_identifier.clitest
@@ -19,9 +19,7 @@ EOF
 
 RUN bundle schema.json --resolve nested.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
 REPLACE $CWD WITH '[CWD]' IN result.txt

--- a/test/bundle/pass_resolve_single.clitest
+++ b/test/bundle/pass_resolve_single.clitest
@@ -21,9 +21,7 @@ EOF
 
 RUN bundle schema.json --resolve remote.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_resolve_single_default_dialect.clitest
+++ b/test/bundle/pass_resolve_single_default_dialect.clitest
@@ -21,9 +21,7 @@ EOF
 
 RUN bundle schema.json --resolve remote.json --default-dialect https://json-schema.org/draft/2020-12/schema STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_resolve_with_ignore.clitest
+++ b/test/bundle/pass_resolve_with_ignore.clitest
@@ -33,9 +33,7 @@ EOF
 
 RUN bundle schema.json --resolve schemas --ignore schemas/duplicated.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_resolve_yaml.clitest
+++ b/test/bundle/pass_resolve_yaml.clitest
@@ -19,9 +19,7 @@ EOF
 
 RUN bundle schema.yaml --resolve remote.yaml STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_without_extension_json.clitest
+++ b/test/bundle/pass_without_extension_json.clitest
@@ -21,9 +21,7 @@ EOF
 
 RUN bundle schema --resolve remote STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_without_extension_yaml.clitest
+++ b/test/bundle/pass_without_extension_yaml.clitest
@@ -17,9 +17,7 @@ EOF
 
 RUN bundle schema --resolve remote STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_without_id.clitest
+++ b/test/bundle/pass_without_id.clitest
@@ -23,9 +23,7 @@ EOF
 
 RUN bundle schema.json --resolve schemas --without-id STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/bundle/pass_without_remote.clitest
+++ b/test/bundle/pass_without_remote.clitest
@@ -16,9 +16,7 @@ EOF
 
 RUN bundle schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COPY result.txt TO bundled.json
-KEEP LINES MATCHING '^1>' IN bundled.json
-REPLACE '^1> ?' WITH '' IN bundled.json
+EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 WRITE expected_0.txt UNTIL EOF
 1> {

--- a/test/compile/pass_patternproperties.clitest
+++ b/test/compile/pass_patternproperties.clitest
@@ -20,9 +20,7 @@ EOF
 
 RUN compile schema.json STDIN /dev/null IN . INTO compiled.txt EXPECTING 0
 
-COPY compiled.txt TO template.json
-KEEP LINES MATCHING '^1>' IN template.json
-REPLACE '^1> ?' WITH '' IN template.json
+EXTRACT STDOUT FROM compiled.txt INTO template.json
 
 RUN validate --template template.json schema.json instance.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 

--- a/test/test/fail_false_single_resolve_json.clitest
+++ b/test/test/fail_false_single_resolve_json.clitest
@@ -22,9 +22,7 @@ EOF
 // Validation failure
 RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-COPY result_0.txt TO output.json
-KEEP LINES MATCHING '^1>' IN output.json
-REPLACE '^1> ?' WITH '' IN output.json
+EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
 DROP LINES MATCHING '"duration":' IN result_0.txt

--- a/test/test/fail_multi_jobs_json.clitest
+++ b/test/test/fail_multi_jobs_json.clitest
@@ -73,9 +73,7 @@ EOF
 // Test assertion failure
 RUN test tests --resolve schema.json --json --jobs 3 STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-COPY result.txt TO report.json
-KEEP LINES MATCHING '^1>' IN report.json
-REPLACE '^1> ?' WITH '' IN report.json
+EXTRACT STDOUT FROM result.txt INTO report.json
 
 RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 

--- a/test/test/fail_multi_target_resolve.clitest
+++ b/test/test/fail_multi_target_resolve.clitest
@@ -53,9 +53,7 @@ COMPARE result_0.txt AGAINST expected_0.txt
 // Validation failure
 RUN test test.json --resolve schemas --json STDIN /dev/null IN . INTO result_1.txt EXPECTING 2
 
-COPY result_1.txt TO output.json
-KEEP LINES MATCHING '^1>' IN output.json
-REPLACE '^1> ?' WITH '' IN output.json
+EXTRACT STDOUT FROM result_1.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_1.txt
 DROP LINES MATCHING '"duration":' IN result_1.txt

--- a/test/test/fail_rdf_invalid_instance_json.clitest
+++ b/test/test/fail_rdf_invalid_instance_json.clitest
@@ -30,9 +30,7 @@ EOF
 // Test assertion failure
 RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-COPY result.txt TO report.json
-KEEP LINES MATCHING '^1>' IN report.json
-REPLACE '^1> ?' WITH '' IN report.json
+EXTRACT STDOUT FROM result.txt INTO report.json
 
 RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 

--- a/test/test/fail_rdf_mismatch_json.clitest
+++ b/test/test/fail_rdf_mismatch_json.clitest
@@ -29,9 +29,7 @@ EOF
 // Test assertion failure
 RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-COPY result.txt TO report.json
-KEEP LINES MATCHING '^1>' IN report.json
-REPLACE '^1> ?' WITH '' IN report.json
+EXTRACT STDOUT FROM result.txt INTO report.json
 
 RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 

--- a/test/test/fail_rdf_resolution_json.clitest
+++ b/test/test/fail_rdf_resolution_json.clitest
@@ -34,9 +34,7 @@ EOF
 // Test assertion failure
 RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-COPY result.txt TO report.json
-KEEP LINES MATCHING '^1>' IN report.json
-REPLACE '^1> ?' WITH '' IN report.json
+EXTRACT STDOUT FROM result.txt INTO report.json
 
 RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 

--- a/test/test/fail_tests_empty.clitest
+++ b/test/test/fail_tests_empty.clitest
@@ -29,9 +29,7 @@ COMPARE result_0.txt AGAINST expected_0.txt
 // Other input error
 RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result_1.txt EXPECTING 6
 
-COPY result_1.txt TO output.json
-KEEP LINES MATCHING '^1>' IN output.json
-REPLACE '^1> ?' WITH '' IN output.json
+EXTRACT STDOUT FROM result_1.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_1.txt
 DROP LINES MATCHING '"start":' IN result_1.txt

--- a/test/test/fail_tests_empty_jobs_json.clitest
+++ b/test/test/fail_tests_empty_jobs_json.clitest
@@ -46,9 +46,7 @@ EOF
 // Other input error
 RUN test tests --resolve schema.json --json --jobs 2 STDIN /dev/null IN . INTO result_0.txt EXPECTING 6
 
-COPY result_0.txt TO output.json
-KEEP LINES MATCHING '^1>' IN output.json
-REPLACE '^1> ?' WITH '' IN output.json
+EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
 DROP LINES MATCHING '"duration":' IN result_0.txt
@@ -111,9 +109,7 @@ RUN validate $CTRF_SCHEMA output.json STDIN /dev/null IN . INTO result_1.txt EXP
 // Other input error
 RUN test tests --resolve schema.json --json --jobs 1 STDIN /dev/null IN . INTO result_2.txt EXPECTING 6
 
-COPY result_2.txt TO output.json
-KEEP LINES MATCHING '^1>' IN output.json
-REPLACE '^1> ?' WITH '' IN output.json
+EXTRACT STDOUT FROM result_2.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_2.txt
 DROP LINES MATCHING '"duration":' IN result_2.txt

--- a/test/test/fail_true_single_resolve_json.clitest
+++ b/test/test/fail_true_single_resolve_json.clitest
@@ -25,9 +25,7 @@ EOF
 // Test assertion failure
 RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-COPY result.txt TO report.json
-KEEP LINES MATCHING '^1>' IN report.json
-REPLACE '^1> ?' WITH '' IN report.json
+EXTRACT STDOUT FROM result.txt INTO report.json
 
 RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 

--- a/test/test/pass_file_target_without_resolve_json.clitest
+++ b/test/test/pass_file_target_without_resolve_json.clitest
@@ -27,9 +27,7 @@ EOF
 
 RUN test this/is/a/very/very/very/long/path/test.json --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-COPY result_0.txt TO output.json
-KEEP LINES MATCHING '^1>' IN output.json
-REPLACE '^1> ?' WITH '' IN output.json
+EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
 DROP LINES MATCHING '"duration":' IN result_0.txt

--- a/test/test/pass_multi_jobs_json.clitest
+++ b/test/test/pass_multi_jobs_json.clitest
@@ -64,9 +64,7 @@ EOF
 
 RUN test tests --resolve schema.json --json --jobs 2 STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-COPY result_0.txt TO output.json
-KEEP LINES MATCHING '^1>' IN output.json
-REPLACE '^1> ?' WITH '' IN output.json
+EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
 DROP LINES MATCHING '"duration":' IN result_0.txt
@@ -148,9 +146,7 @@ RUN validate $CTRF_SCHEMA output.json STDIN /dev/null IN . INTO result_1.txt EXP
 
 RUN test tests --resolve schema.json --json --jobs 1 STDIN /dev/null IN . INTO result_2.txt EXPECTING 0
 
-COPY result_2.txt TO output.json
-KEEP LINES MATCHING '^1>' IN output.json
-REPLACE '^1> ?' WITH '' IN output.json
+EXTRACT STDOUT FROM result_2.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_2.txt
 DROP LINES MATCHING '"duration":' IN result_2.txt

--- a/test/test/pass_multi_target_resolve_json.clitest
+++ b/test/test/pass_multi_target_resolve_json.clitest
@@ -39,9 +39,7 @@ EOF
 
 RUN test test.json --resolve schemas --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-COPY result_0.txt TO output.json
-KEEP LINES MATCHING '^1>' IN output.json
-REPLACE '^1> ?' WITH '' IN output.json
+EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
 DROP LINES MATCHING '"duration":' IN result_0.txt

--- a/test/test/pass_single_no_description_json.clitest
+++ b/test/test/pass_single_no_description_json.clitest
@@ -20,9 +20,7 @@ EOF
 
 RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-COPY result_0.txt TO output.json
-KEEP LINES MATCHING '^1>' IN output.json
-REPLACE '^1> ?' WITH '' IN output.json
+EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
 DROP LINES MATCHING '"duration":' IN result_0.txt

--- a/test/test/pass_single_resolve_json.clitest
+++ b/test/test/pass_single_resolve_json.clitest
@@ -26,9 +26,7 @@ EOF
 
 RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-COPY result_0.txt TO output.json
-KEEP LINES MATCHING '^1>' IN output.json
-REPLACE '^1> ?' WITH '' IN output.json
+EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
 DROP LINES MATCHING '"duration":' IN result_0.txt

--- a/test/validate/pass_2020_12_fast_with_template.clitest
+++ b/test/validate/pass_2020_12_fast_with_template.clitest
@@ -17,9 +17,7 @@ EOF
 
 RUN compile schema.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-COPY result_0.txt TO template.json
-KEEP LINES MATCHING '^1>' IN template.json
-REPLACE '^1> ?' WITH '' IN template.json
+EXTRACT STDOUT FROM result_0.txt INTO template.json
 
 RUN validate schema.json instance.json --fast --template template.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 

--- a/test/validate/pass_2020_12_with_template.clitest
+++ b/test/validate/pass_2020_12_with_template.clitest
@@ -17,9 +17,7 @@ EOF
 
 RUN compile schema.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-COPY result_0.txt TO template.json
-KEEP LINES MATCHING '^1>' IN template.json
-REPLACE '^1> ?' WITH '' IN template.json
+EXTRACT STDOUT FROM result_0.txt INTO template.json
 
 RUN validate schema.json instance.json --template template.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 

--- a/test/validate/pass_trace_with_template.clitest
+++ b/test/validate/pass_trace_with_template.clitest
@@ -18,9 +18,7 @@ EOF
 
 RUN compile schema.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-COPY result_0.txt TO template.json
-KEEP LINES MATCHING '^1>' IN template.json
-REPLACE '^1> ?' WITH '' IN template.json
+EXTRACT STDOUT FROM result_0.txt INTO template.json
 
 RUN validate schema.json instance.json --trace --template template.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 

--- a/test/validate/pass_verbose_with_template.clitest
+++ b/test/validate/pass_verbose_with_template.clitest
@@ -17,9 +17,7 @@ EOF
 
 RUN compile schema.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-COPY result_0.txt TO template.json
-KEEP LINES MATCHING '^1>' IN template.json
-REPLACE '^1> ?' WITH '' IN template.json
+EXTRACT STDOUT FROM result_0.txt INTO template.json
 
 RUN validate schema.json instance.json --verbose --template template.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

