### PR TITLE
Derive the expected version in the help tests from `$VERSION`

### DIFF
--- a/test/help_command.clitest
+++ b/test/help_command.clitest
@@ -1,8 +1,9 @@
 RUN help STDIN /dev/null IN . INTO result.txt EXPECTING 0
 REPLACE '\.exe' WITH '' IN result.txt
+REPLACE $VERSION WITH '[VERSION]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
-1> JSON Schema CLI - v16.7.0
+1> JSON Schema CLI - v[VERSION]
 1> Usage: jsonschema <command> [arguments...]
 1>
 1> Global Options:

--- a/test/help_option_long.clitest
+++ b/test/help_option_long.clitest
@@ -1,8 +1,9 @@
 RUN --help STDIN /dev/null IN . INTO result.txt EXPECTING 0
 REPLACE '\.exe' WITH '' IN result.txt
+REPLACE $VERSION WITH '[VERSION]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
-1> JSON Schema CLI - v16.7.0
+1> JSON Schema CLI - v[VERSION]
 1> Usage: jsonschema <command> [arguments...]
 1>
 1> Global Options:

--- a/test/help_option_short.clitest
+++ b/test/help_option_short.clitest
@@ -1,8 +1,9 @@
 RUN -h STDIN /dev/null IN . INTO result.txt EXPECTING 0
 REPLACE '\.exe' WITH '' IN result.txt
+REPLACE $VERSION WITH '[VERSION]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
-1> JSON Schema CLI - v16.7.0
+1> JSON Schema CLI - v[VERSION]
 1> Usage: jsonschema <command> [arguments...]
 1>
 1> Global Options:


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

