### PR TITLE
Fix `validate --benchmark` printing errors twice

### DIFF
--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -143,7 +143,6 @@ auto process_entry(
     std::uint64_t benchmark_loop, bool trace, bool fast_mode, bool json_output,
     bool continue_on_error, const std::filesystem::path &schema_resolution_base,
     const sourcemeta::core::Options &options, bool &result) -> bool {
-  std::ostringstream error;
   sourcemeta::blaze::SimpleOutput output{entry.second};
   sourcemeta::blaze::TraceOutput trace_output{
       sourcemeta::blaze::schema_walker, custom_resolver,
@@ -157,7 +156,6 @@ auto process_entry(
                              : static_cast<std::int64_t>(-1),
                          benchmark_loop);
     if (!subresult) {
-      error << "error: Schema validation failure\n";
       result = false;
     }
   } else if (trace) {
@@ -221,7 +219,6 @@ auto process_entry(
     } else {
       std::cerr << "\n";
     }
-    std::cerr << error.str();
     sourcemeta::jsonschema::print(output, entry.positions, std::cerr);
     result = false;
     if (entry.multidocument && !continue_on_error) {
@@ -425,7 +422,6 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
           }
           return sourcemeta::core::read_yaml_or_json(instance_path);
         }()};
-        std::ostringstream error;
         sourcemeta::blaze::SimpleOutput output{instance};
         sourcemeta::blaze::TraceOutput trace_output{
             sourcemeta::blaze::schema_walker, custom_resolver,
@@ -437,7 +433,6 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
                                instance_path.generic_string(), (int64_t)-1,
                                benchmark_loop);
           if (!subresult) {
-            error << "error: Schema validation failure\n";
             result = false;
           }
         } else if (trace) {
@@ -480,7 +475,6 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
                     << sourcemeta::core::weakly_canonical(instance_path)
                            .generic_string()
                     << "\n";
-          std::cerr << error.str();
           print(output, tracker, std::cerr);
           result = false;
         }

--- a/test/validate/fail_benchmark.clitest
+++ b/test/validate/fail_benchmark.clitest
@@ -26,7 +26,6 @@ WRITE expected_0.txt UNTIL EOF
 1> instance.json: FAIL [TIMING]
 2> fail: [CWD]/instance.json
 2> error: Schema validation failure
-2> error: Schema validation failure
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

