### PR TITLE
Clearly separate literals and patterns in the test DSL

### DIFF
--- a/scripts/clitest.py
+++ b/scripts/clitest.py
@@ -49,10 +49,11 @@ called `OUT` cannot consume the front of `$OUTPUT`.
 
 A pattern is never expanded, so `$` in one is the regular expression anchor and
 nothing else: `^abc$`, `a{2}$` and `$$` all mean what they say, and a dollar
-sign that really does precede a name is escaped, as in `\\$schema`. What
-remains, an unescaped `$` followed by a name, is rejected rather than matched.
-An anchor is zero width, so such a pattern could match no input at all, and an
-author who writes one almost certainly wanted the literal form.
+sign that really does precede a name is written `\\$schema`, or `[$a]` inside a
+character class. What remains, an unescaped `$` followed by a name and outside
+a class, is rejected rather than matched. An anchor is zero width, so such a
+pattern could match no input at all, and an author who writes one almost
+certainly wanted the literal form.
 
 `RUN` is read from the end: the last eight tokens are its trailer, and anything
 before them is passed to the binary. `STDIN /dev/null` means empty input on
@@ -114,18 +115,45 @@ VARIABLE = re.compile(
     r"\$\$|\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
 
 
+def end_of_character_class(pattern, index):
+    """The index just past the character class opening at `index`.
+
+    A closing bracket is itself an ordinary character when it opens the class,
+    after an optional negating caret. An unterminated class is not a class at
+    all, so it is left for the engine to reject.
+    """
+    cursor = index + 1
+    if cursor < len(pattern) and pattern[cursor] == "^":
+        cursor += 1
+    if cursor < len(pattern) and pattern[cursor] == "]":
+        cursor += 1
+    while cursor < len(pattern):
+        if pattern[cursor] == "\\":
+            cursor += 2
+        elif pattern[cursor] == "]":
+            return cursor + 1
+        else:
+            cursor += 1
+    return index + 1
+
+
 def variable_reference(pattern):
     """The first variable reference in a pattern, or None if it holds none.
 
     Read with the same scanner as an operand, but a pattern is a regular
-    expression rather than text, so two of its shapes are not references at
+    expression rather than text, so three of its shapes are not references at
     all. A backslash escapes what follows it, making `\\$schema` a dollar sign
-    before a name, and `$$` is a pair of anchors rather than an escaped dollar.
+    before a name. `$$` is a pair of anchors rather than an escaped dollar. And
+    a dollar sign inside a character class is an ordinary character, so `[$a]`
+    is a class holding one.
     """
     index = 0
     while index < len(pattern):
         if pattern[index] == "\\":
             index += 2
+            continue
+        if pattern[index] == "[":
+            index = end_of_character_class(pattern, index)
             continue
         match = VARIABLE.match(pattern, index)
         if match is None:
@@ -521,7 +549,19 @@ def check(statements):
 
     for position, statement in enumerate(statements):
         operands = statement.operands
-        for token in operands:
+        # A pattern is never expanded, so a name appearing inside one is not a
+        # use of that name, however it is spelled. Reading it as one would let
+        # a checksum nothing ever expands pass this check
+        if statement.keyword == "REPLACE" and len(operands) == 6 \
+                and operands[0] == "MATCHING":
+            scanned = operands[:1] + operands[2:]
+        elif statement.keyword == "DROP" and len(operands) == 5 \
+                and operands[1] == "MATCHING":
+            scanned = operands[:2] + operands[3:]
+        else:
+            scanned = operands
+
+        for token in scanned:
             for match in VARIABLE.finditer(token):
                 name = match.group(1) or match.group(2)
                 # A `$$` match names nothing, being an escaped dollar sign

--- a/scripts/clitest.py
+++ b/scripts/clitest.py
@@ -47,10 +47,12 @@ in a JSON Pointer like `/$$defs/Foo`. `$$` is matched before any name, so it
 never yields a variable reference, and names are matched greedily, so a binding
 called `OUT` cannot consume the front of `$OUTPUT`.
 
-Sharing `$` with the regular expression anchor is safe, because an anchor is
-zero width and so can never be meaningfully followed by a name. `^abc$`, `a{2}$`
-and `a${2}` all pass through untouched. The one shape that does read as a
-variable, `foo$bar`, describes a match that no input could satisfy anyway.
+A pattern is never expanded, so `$` in one is the regular expression anchor and
+nothing else: `^abc$`, `a{2}$` and `$$` all mean what they say, and a dollar
+sign that really does precede a name is escaped, as in `\\$schema`. What
+remains, an unescaped `$` followed by a name, is rejected rather than matched.
+An anchor is zero width, so such a pattern could match no input at all, and an
+author who writes one almost certainly wanted the literal form.
 
 `RUN` is read from the end: the last eight tokens are its trailer, and anything
 before them is passed to the binary. `STDIN /dev/null` means empty input on
@@ -112,6 +114,29 @@ VARIABLE = re.compile(
     r"\$\$|\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
 
 
+def variable_reference(pattern):
+    """The first variable reference in a pattern, or None if it holds none.
+
+    Read with the same scanner as an operand, but a pattern is a regular
+    expression rather than text, so two of its shapes are not references at
+    all. A backslash escapes what follows it, making `\\$schema` a dollar sign
+    before a name, and `$$` is a pair of anchors rather than an escaped dollar.
+    """
+    index = 0
+    while index < len(pattern):
+        if pattern[index] == "\\":
+            index += 2
+            continue
+        match = VARIABLE.match(pattern, index)
+        if match is None:
+            index += 1
+        elif match.group(0) == "$$":
+            index = match.end()
+        else:
+            return match.group(0)
+    return None
+
+
 class Interpreter:
     def __init__(self, binary, sandbox, environment):
         self.binary = binary
@@ -147,10 +172,11 @@ class Interpreter:
         # one out of a variable is what keeps the two forms from ever meeting,
         # and so is what removes the escaping rule that would otherwise be
         # needed to stop an expanded path from being read as more pattern
-        if VARIABLE.search(token):
+        reference = variable_reference(token)
+        if reference is not None:
             raise TestFailure(
                 line_number,
-                f"a pattern is taken verbatim and cannot expand a variable, "
+                f"a pattern is taken verbatim and cannot expand {reference}, "
                 f"so use the literal form instead: {token}")
         try:
             return re.compile(token, re.MULTILINE)

--- a/scripts/clitest.py
+++ b/scripts/clitest.py
@@ -10,7 +10,9 @@ containing spaces or a regular expression is single quoted.
                                         to <terminator>, becomes the file
     RUN [argument...] STDIN <path> IN <directory> INTO <path> EXPECTING <code>
     COMPARE <actual> AGAINST <expected>
-    REPLACE <pattern> WITH <replacement> IN <path>
+    REPLACE <text> WITH <replacement> IN <path>
+    REPLACE MATCHING <pattern> WITH <replacement> IN <path>
+    DROP LINES CONTAINING <text> IN <path>
     DROP LINES MATCHING <pattern> IN <path>
     EXTRACT STDOUT FROM <observation> INTO <destination>
     SORT <path>
@@ -57,12 +59,17 @@ captured into one observation file, each line prefixed with `1> ` or `2> `, an
 empty line becoming a bare prefix. CRLF is normalised to LF and one trailing
 newline is dropped, so observations compare identically across platforms.
 
-Patterns are regular expressions applied in multiline mode, which makes `$`
-match before every newline; `\\Z` is the way to mean end of input. A variable
-expanded inside a pattern stands for literal text rather than for more pattern,
-so a sandbox path holding regular expression punctuation still matches itself. A
-replacement is literal text too: backslashes in it are escaped before use, so it
-cannot reference a capture group and cannot introduce a control character.
+A filter matches literal text by default, which is what nearly every one of them
+wants: a sandbox path, a hash, a version number. `MATCHING` opts into a regular
+expression instead, applied in multiline mode, which makes `$` match before
+every newline, with `\\Z` meaning end of input.
+
+Keeping the two apart is what removes escaping from the language. A literal
+operand needs none, because nothing in it is special. A pattern needs none
+either, because it is taken verbatim and never expands a variable, so a sandbox
+path full of regular expression punctuation can never leak into one. The two
+forms never meet. A replacement is literal in both, and is expanded, so it
+cannot reference a capture group.
 
 A test that produces something and never asserts on it is rejected before it
 runs, on the grounds that a command whose result nothing reads is a command
@@ -135,16 +142,20 @@ class Interpreter:
 
         return VARIABLE.sub(replace, token)
 
-    def expand_pattern(self, token, line_number):
-        def replace(match):
-            if match.group(0) == "$$":
-                return re.escape("$")
-            name = match.group(1) or match.group(2)
-            if name not in self.environment:
-                raise TestFailure(line_number, f"undefined variable: ${name}")
-            return re.escape(self.environment[name])
-
-        return VARIABLE.sub(replace, token)
+    def compile_pattern(self, token, line_number):
+        # A pattern is the one operand that is not expanded. Refusing to build
+        # one out of a variable is what keeps the two forms from ever meeting,
+        # and so is what removes the escaping rule that would otherwise be
+        # needed to stop an expanded path from being read as more pattern
+        if VARIABLE.search(token):
+            raise TestFailure(
+                line_number,
+                f"a pattern is taken verbatim and cannot expand a variable, "
+                f"so use the literal form instead: {token}")
+        try:
+            return re.compile(token, re.MULTILINE)
+        except re.error as error:
+            raise TestFailure(line_number, f"bad pattern: {error}")
 
     def resolve(self, path, line_number):
         expanded = self.expand(path, line_number)
@@ -256,32 +267,49 @@ class Interpreter:
                 fromfile=operands[2], tofile=operands[0])
             raise TestFailure(line_number, "".join(diff))
 
-    def command_filter(self, keyword, operands, line_number):
-        if keyword == "REPLACE":
-            if len(operands) != 5 or operands[1] != "WITH" or operands[3] != "IN":
-                raise TestFailure(
-                    line_number, "usage: REPLACE <regex> WITH <replacement> IN <file>")
-            pattern, replacement, name = operands[0], operands[2], operands[4]
+    def command_replace(self, operands, line_number):
+        # The two forms are told apart by length, so that replacing the literal
+        # text "MATCHING" stays possible
+        if len(operands) == 6 and operands[0] == "MATCHING" \
+                and operands[2] == "WITH" and operands[4] == "IN":
+            expression = self.compile_pattern(operands[1], line_number)
+            replacement, name = operands[3], operands[5]
+        elif len(operands) == 5 and operands[1] == "WITH" \
+                and operands[3] == "IN":
+            expression, replacement, name = None, operands[2], operands[4]
         else:
-            if len(operands) != 5 or operands[0] != "LINES" \
-                    or operands[1] != "MATCHING" or operands[3] != "IN":
-                raise TestFailure(
-                    line_number, "usage: DROP LINES MATCHING <regex> IN <file>")
-            pattern, replacement, name = operands[2], None, operands[4]
+            raise TestFailure(
+                line_number,
+                "usage: REPLACE [MATCHING] <pattern> WITH <replacement> IN <file>")
 
         path = self.resolve(name, line_number)
         content = self.read(path, line_number)
-        expression = re.compile(
-            self.expand_pattern(pattern, line_number), re.MULTILINE)
-
-        if keyword == "REPLACE":
-            content = expression.sub(
-                self.expand(replacement, line_number).replace("\\", "\\\\"), content)
+        expanded = self.expand(replacement, line_number)
+        if expression is None:
+            content = content.replace(
+                self.expand(operands[0], line_number), expanded)
         else:
-            content = "".join(
-                line for line in content.splitlines(keepends=True)
-                if not expression.search(line))
+            # Substituting through a function rather than a template string is
+            # what keeps the replacement literal without escaping it first
+            content = expression.sub(lambda match: expanded, content)
         self.write(path, content)
+
+    def command_drop(self, operands, line_number):
+        if len(operands) != 5 or operands[0] != "LINES" or operands[3] != "IN" \
+                or operands[1] not in ("CONTAINING", "MATCHING"):
+            raise TestFailure(
+                line_number,
+                "usage: DROP LINES CONTAINING|MATCHING <pattern> IN <file>")
+
+        path = self.resolve(operands[4], line_number)
+        lines = self.read(path, line_number).splitlines(keepends=True)
+        if operands[1] == "CONTAINING":
+            text = self.expand(operands[2], line_number)
+            kept = [line for line in lines if text not in line]
+        else:
+            expression = self.compile_pattern(operands[2], line_number)
+            kept = [line for line in lines if not expression.search(line)]
+        self.write(path, "".join(kept))
 
     def command_tree(self, operands, line_number):
         if len(operands) != 3 or operands[1] != "INTO":
@@ -575,8 +603,10 @@ def run_script(path, binary, environment):
                 interpreter.command_compare(rest, number)
             elif keyword == "ENV":
                 interpreter.command_env(rest, number)
-            elif keyword in ("REPLACE", "DROP"):
-                interpreter.command_filter(keyword, rest, number)
+            elif keyword == "REPLACE":
+                interpreter.command_replace(rest, number)
+            elif keyword == "DROP":
+                interpreter.command_drop(rest, number)
             elif keyword == "TREE":
                 interpreter.command_tree(rest, number)
             elif keyword == "COPY":

--- a/test/bundle/pass_resolve_installed_dependency.clitest
+++ b/test/bundle/pass_resolve_installed_dependency.clitest
@@ -16,7 +16,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO installed.txt EXPECTING 0
 

--- a/test/bundle/pass_resolve_installed_dependency_by_uri.clitest
+++ b/test/bundle/pass_resolve_installed_dependency_by_uri.clitest
@@ -16,7 +16,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO installed.txt EXPECTING 0
 
@@ -38,7 +38,7 @@ WRITE project/schema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/schema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/schema.json
 
 RUN bundle project/schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 

--- a/test/ci/pass_install_add_http.clitest
+++ b/test/ci/pass_install_add_http.clitest
@@ -55,7 +55,7 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json
 

--- a/test/ci/pass_install_http.clitest
+++ b/test/ci/pass_install_http.clitest
@@ -226,7 +226,7 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json
 

--- a/test/help_command.clitest
+++ b/test/help_command.clitest
@@ -1,5 +1,5 @@
 RUN help STDIN /dev/null IN . INTO result.txt EXPECTING 0
-REPLACE '\.exe' WITH '' IN result.txt
+REPLACE .exe WITH '' IN result.txt
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
 
 WRITE expected.txt UNTIL EOF

--- a/test/help_option_long.clitest
+++ b/test/help_option_long.clitest
@@ -1,5 +1,5 @@
 RUN --help STDIN /dev/null IN . INTO result.txt EXPECTING 0
-REPLACE '\.exe' WITH '' IN result.txt
+REPLACE .exe WITH '' IN result.txt
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
 
 WRITE expected.txt UNTIL EOF

--- a/test/help_option_short.clitest
+++ b/test/help_option_short.clitest
@@ -1,5 +1,5 @@
 RUN -h STDIN /dev/null IN . INTO result.txt EXPECTING 0
-REPLACE '\.exe' WITH '' IN result.txt
+REPLACE .exe WITH '' IN result.txt
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
 
 WRITE expected.txt UNTIL EOF

--- a/test/install/fail_creates_parent_over_file.clitest
+++ b/test/install/fail_creates_parent_over_file.clitest
@@ -20,7 +20,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 // Other input error
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 6

--- a/test/install/fail_frozen_hash_mismatch.clitest
+++ b/test/install/fail_frozen_hash_mismatch.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/fail_frozen_multiple_errors.clitest
+++ b/test/install/fail_frozen_multiple_errors.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/fail_frozen_orphaned.clitest
+++ b/test/install/fail_frozen_orphaned.clitest
@@ -25,7 +25,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -49,7 +49,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 COPY project/jsonschema.lock.json TO lock_before.json
 

--- a/test/install/fail_frozen_path_mismatch.clitest
+++ b/test/install/fail_frozen_path_mismatch.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 WRITE project/jsonschema.lock.json UNTIL EOF
 {
@@ -32,8 +32,8 @@ WRITE project/jsonschema.lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.lock.json
-REPLACE '\[CWD\]' WITH $CWD IN project/jsonschema.lock.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.lock.json
+REPLACE '[CWD]' WITH $CWD IN project/jsonschema.lock.json
 
 COPY project/jsonschema.lock.json TO lock_before.json
 

--- a/test/install/fail_frozen_untracked.clitest
+++ b/test/install/fail_frozen_untracked.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -40,7 +40,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 COPY project/jsonschema.lock.json TO lock_before.json
 

--- a/test/install/fail_frozen_written_hash_mismatch.clitest
+++ b/test/install/fail_frozen_written_hash_mismatch.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_add_dependency.clitest
+++ b/test/install/pass_add_dependency.clitest
@@ -75,6 +75,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_add_dependency_existing_deps.clitest
+++ b/test/install/pass_add_dependency_existing_deps.clitest
@@ -24,7 +24,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -106,7 +106,7 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH_PRODUCT\]' WITH $HASH_PRODUCT IN expected_lock.json
-REPLACE '\[HASH_USER\]' WITH $HASH_USER IN expected_lock.json
+REPLACE '[HASH_PRODUCT]' WITH $HASH_PRODUCT IN expected_lock.json
+REPLACE '[HASH_USER]' WITH $HASH_USER IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_add_dependency_force.clitest
+++ b/test/install/pass_add_dependency_force.clitest
@@ -24,7 +24,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -121,7 +121,7 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH_PRODUCT\]' WITH $HASH_PRODUCT IN expected_lock.json
-REPLACE '\[HASH_USER\]' WITH $HASH_USER IN expected_lock.json
+REPLACE '[HASH_PRODUCT]' WITH $HASH_PRODUCT IN expected_lock.json
+REPLACE '[HASH_USER]' WITH $HASH_USER IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_add_dependency_json.clitest
+++ b/test/install/pass_add_dependency_json.clitest
@@ -90,6 +90,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_add_dependency_no_config.clitest
+++ b/test/install/pass_add_dependency_no_config.clitest
@@ -69,6 +69,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_add_dependency_outside_path.clitest
+++ b/test/install/pass_add_dependency_outside_path.clitest
@@ -77,6 +77,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_add_dependency_overwrite.clitest
+++ b/test/install/pass_add_dependency_overwrite.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install $CWD_URI/source/user.json ./vendor/new_path.json STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -87,6 +87,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_add_dependency_preserve_config.clitest
+++ b/test/install/pass_add_dependency_preserve_config.clitest
@@ -79,6 +79,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_already_installed.clitest
+++ b/test/install/pass_already_installed.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -75,6 +75,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_already_installed_json.clitest
+++ b/test/install/pass_already_installed_json.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -82,6 +82,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_corrupted_lock_invalid_format.clitest
+++ b/test/install/pass_corrupted_lock_invalid_format.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 WRITE project/jsonschema.lock.json UNTIL EOF
 {
@@ -72,6 +72,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_corrupted_lock_malformed.clitest
+++ b/test/install/pass_corrupted_lock_malformed.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 WRITE project/jsonschema.lock.json UNTIL EOF
 NOT VALID JSON
@@ -70,6 +70,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_corrupted_lock_malformed_json.clitest
+++ b/test/install/pass_corrupted_lock_malformed_json.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 WRITE project/jsonschema.lock.json UNTIL EOF
 NOT VALID JSON
@@ -83,6 +83,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_creates_parent_directories.clitest
+++ b/test/install/pass_creates_parent_directories.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -64,6 +64,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_debug_output.clitest
+++ b/test/install/pass_debug_output.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install --debug STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -76,6 +76,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_dependency_as_metaschema.clitest
+++ b/test/install/pass_dependency_as_metaschema.clitest
@@ -14,7 +14,7 @@ WRITE source/custom_meta.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN source/custom_meta.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN source/custom_meta.json
 
 WRITE source/my_schema.json UNTIL EOF
 {
@@ -28,7 +28,7 @@ WRITE source/my_schema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN source/my_schema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN source/my_schema.json
 
 WRITE project/jsonschema.json UNTIL EOF
 {
@@ -39,7 +39,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -128,7 +128,7 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH_META\]' WITH $HASH_META IN expected_lock.json
-REPLACE '\[HASH_SCHEMA\]' WITH $HASH_SCHEMA IN expected_lock.json
+REPLACE '[HASH_META]' WITH $HASH_META IN expected_lock.json
+REPLACE '[HASH_SCHEMA]' WITH $HASH_SCHEMA IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_fetch_file_uri.clitest
+++ b/test/install/pass_fetch_file_uri.clitest
@@ -22,7 +22,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -74,6 +74,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_fetch_file_uri_no_bundle_param.clitest
+++ b/test/install/pass_fetch_file_uri_no_bundle_param.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -64,6 +64,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_force_reinstall.clitest
+++ b/test/install/pass_force_reinstall.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -76,6 +76,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_frozen_debug_output.clitest
+++ b/test/install/pass_frozen_debug_output.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_frozen_idempotent.clitest
+++ b/test/install/pass_frozen_idempotent.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_frozen_installs_missing.clitest
+++ b/test/install/pass_frozen_installs_missing.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_frozen_installs_missing_creates_dirs.clitest
+++ b/test/install/pass_frozen_installs_missing_creates_dirs.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_frozen_mixed_status.clitest
+++ b/test/install/pass_frozen_mixed_status.clitest
@@ -25,7 +25,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_frozen_multiple_dependencies.clitest
+++ b/test/install/pass_frozen_multiple_dependencies.clitest
@@ -25,7 +25,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_frozen_resolve_mapping.clitest
+++ b/test/install/pass_frozen_resolve_mapping.clitest
@@ -29,7 +29,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_frozen_subdir.clitest
+++ b/test/install/pass_frozen_subdir.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_frozen_up_to_date.clitest
+++ b/test/install/pass_frozen_up_to_date.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_frozen_up_to_date_json.clitest
+++ b/test/install/pass_frozen_up_to_date_json.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_frozen_verbose_output.clitest
+++ b/test/install/pass_frozen_verbose_output.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 

--- a/test/install/pass_header_does_not_break_file_uri.clitest
+++ b/test/install/pass_header_does_not_break_file_uri.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install -H 'Authorization: Bearer xyz' -H 'X-Custom: 1' STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -64,6 +64,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_lock_file_with_path.clitest
+++ b/test/install/pass_lock_file_with_path.clitest
@@ -18,7 +18,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -65,7 +65,7 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json
 

--- a/test/install/pass_multiple_dependencies.clitest
+++ b/test/install/pass_multiple_dependencies.clitest
@@ -25,7 +25,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -94,7 +94,7 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH_ALPHA\]' WITH $HASH_ALPHA IN expected_lock.json
-REPLACE '\[HASH_BETA\]' WITH $HASH_BETA IN expected_lock.json
+REPLACE '[HASH_ALPHA]' WITH $HASH_ALPHA IN expected_lock.json
+REPLACE '[HASH_BETA]' WITH $HASH_BETA IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_remove_orphaned_dependency.clitest
+++ b/test/install/pass_remove_orphaned_dependency.clitest
@@ -27,7 +27,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -88,8 +88,8 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH_A\]' WITH $HASH_A IN expected_lock.json
-REPLACE '\[HASH_B\]' WITH $HASH_B IN expected_lock.json
+REPLACE '[HASH_A]' WITH $HASH_A IN expected_lock.json
+REPLACE '[HASH_B]' WITH $HASH_B IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json
 
@@ -101,7 +101,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_1.txt EXPECTING 0
 
@@ -142,6 +142,6 @@ WRITE expected_lock_after.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH_A\]' WITH $HASH_A IN expected_lock_after.json
+REPLACE '[HASH_A]' WITH $HASH_A IN expected_lock_after.json
 
 COMPARE checked_lock_after.json AGAINST expected_lock_after.json

--- a/test/install/pass_remove_orphaned_dependency_json.clitest
+++ b/test/install/pass_remove_orphaned_dependency_json.clitest
@@ -27,7 +27,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -51,7 +51,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install --json STDIN /dev/null IN project INTO result_1.txt EXPECTING 0
 
@@ -112,6 +112,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH_A\]' WITH $HASH_A IN expected_lock.json
+REPLACE '[HASH_A]' WITH $HASH_A IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_resolve_mapping.clitest
+++ b/test/install/pass_resolve_mapping.clitest
@@ -29,7 +29,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -79,6 +79,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_resolver_config_resolve_priority.clitest
+++ b/test/install/pass_resolver_config_resolve_priority.clitest
@@ -30,7 +30,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -81,6 +81,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_resolver_dependency_on_disk.clitest
+++ b/test/install/pass_resolver_dependency_on_disk.clitest
@@ -14,7 +14,7 @@ WRITE source/metaschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN source/metaschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN source/metaschema.json
 
 WRITE source/schema_a.json UNTIL EOF
 {
@@ -23,7 +23,7 @@ WRITE source/schema_a.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN source/schema_a.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN source/schema_a.json
 
 WRITE project/jsonschema.json UNTIL EOF
 {
@@ -34,7 +34,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -118,7 +118,7 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH_META\]' WITH $HASH_META IN expected_lock.json
-REPLACE '\[HASH_A\]' WITH $HASH_A IN expected_lock.json
+REPLACE '[HASH_META]' WITH $HASH_META IN expected_lock.json
+REPLACE '[HASH_A]' WITH $HASH_A IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_resolver_file_uri_fallback.clitest
+++ b/test/install/pass_resolver_file_uri_fallback.clitest
@@ -14,7 +14,7 @@ WRITE source/metaschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN source/metaschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN source/metaschema.json
 
 WRITE source/schema_a.json UNTIL EOF
 {
@@ -23,7 +23,7 @@ WRITE source/schema_a.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN source/schema_a.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN source/schema_a.json
 
 WRITE project/jsonschema.json UNTIL EOF
 {
@@ -34,7 +34,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -118,7 +118,7 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH_META\]' WITH $HASH_META IN expected_lock.json
-REPLACE '\[HASH_A\]' WITH $HASH_A IN expected_lock.json
+REPLACE '[HASH_META]' WITH $HASH_META IN expected_lock.json
+REPLACE '[HASH_A]' WITH $HASH_A IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_resolver_official_schema.clitest
+++ b/test/install/pass_resolver_official_schema.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -50,7 +50,7 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json
 

--- a/test/install/pass_single_dependency.clitest
+++ b/test/install/pass_single_dependency.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -64,6 +64,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_single_dependency_json.clitest
+++ b/test/install/pass_single_dependency_json.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install --json STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -75,6 +75,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_target_already_exists.clitest
+++ b/test/install/pass_target_already_exists.clitest
@@ -23,7 +23,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -70,6 +70,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/install/pass_verbose_output.clitest
+++ b/test/install/pass_verbose_output.clitest
@@ -17,7 +17,7 @@ WRITE project/jsonschema.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[CWD_URI\]' WITH $CWD_URI IN project/jsonschema.json
+REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 
 RUN install --verbose STDIN /dev/null IN project INTO result_0.txt EXPECTING 0
 
@@ -67,6 +67,6 @@ WRITE expected_lock.json UNTIL EOF
 }
 EOF
 
-REPLACE '\[HASH\]' WITH $HASH IN expected_lock.json
+REPLACE '[HASH]' WITH $HASH IN expected_lock.json
 
 COMPARE checked_lock.json AGAINST expected_lock.json

--- a/test/test/fail_false_single_resolve_json.clitest
+++ b/test/test/fail_false_single_resolve_json.clitest
@@ -25,10 +25,10 @@ RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result
 EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
-DROP LINES MATCHING '"duration":' IN result_0.txt
-DROP LINES MATCHING '"start":' IN result_0.txt
-DROP LINES MATCHING '"stop":' IN result_0.txt
-DROP LINES MATCHING '"threadId":' IN result_0.txt
+DROP LINES CONTAINING '"duration":' IN result_0.txt
+DROP LINES CONTAINING '"start":' IN result_0.txt
+DROP LINES CONTAINING '"stop":' IN result_0.txt
+DROP LINES CONTAINING '"threadId":' IN result_0.txt
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF

--- a/test/test/fail_multi_jobs_json.clitest
+++ b/test/test/fail_multi_jobs_json.clitest
@@ -80,10 +80,10 @@ RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EX
 COMPARE validated.txt AGAINST silent.txt
 
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
-DROP LINES MATCHING '"duration":' IN result.txt
-DROP LINES MATCHING '"start":' IN result.txt
-DROP LINES MATCHING '"stop":' IN result.txt
-DROP LINES MATCHING '"threadId":' IN result.txt
+DROP LINES CONTAINING '"duration":' IN result.txt
+DROP LINES CONTAINING '"start":' IN result.txt
+DROP LINES CONTAINING '"stop":' IN result.txt
+DROP LINES CONTAINING '"threadId":' IN result.txt
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF

--- a/test/test/fail_multi_target_resolve.clitest
+++ b/test/test/fail_multi_target_resolve.clitest
@@ -56,11 +56,11 @@ RUN test test.json --resolve schemas --json STDIN /dev/null IN . INTO result_1.t
 EXTRACT STDOUT FROM result_1.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_1.txt
-DROP LINES MATCHING '"duration":' IN result_1.txt
-DROP LINES MATCHING '"start":' IN result_1.txt
-DROP LINES MATCHING '"stop":' IN result_1.txt
-DROP LINES MATCHING '"threadId":' IN result_1.txt
-DROP LINES MATCHING '"trace":' IN result_1.txt
+DROP LINES CONTAINING '"duration":' IN result_1.txt
+DROP LINES CONTAINING '"start":' IN result_1.txt
+DROP LINES CONTAINING '"stop":' IN result_1.txt
+DROP LINES CONTAINING '"threadId":' IN result_1.txt
+DROP LINES CONTAINING '"trace":' IN result_1.txt
 REPLACE $CWD WITH '[CWD]' IN result_1.txt
 
 WRITE expected_1.txt UNTIL EOF

--- a/test/test/fail_rdf_invalid_instance_json.clitest
+++ b/test/test/fail_rdf_invalid_instance_json.clitest
@@ -37,10 +37,10 @@ RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EX
 COMPARE validated.txt AGAINST silent.txt
 
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
-DROP LINES MATCHING '"duration":' IN result.txt
-DROP LINES MATCHING '"start":' IN result.txt
-DROP LINES MATCHING '"stop":' IN result.txt
-DROP LINES MATCHING '"threadId":' IN result.txt
+DROP LINES CONTAINING '"duration":' IN result.txt
+DROP LINES CONTAINING '"start":' IN result.txt
+DROP LINES CONTAINING '"stop":' IN result.txt
+DROP LINES CONTAINING '"threadId":' IN result.txt
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF

--- a/test/test/fail_rdf_mismatch_json.clitest
+++ b/test/test/fail_rdf_mismatch_json.clitest
@@ -36,10 +36,10 @@ RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EX
 COMPARE validated.txt AGAINST silent.txt
 
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
-DROP LINES MATCHING '"duration":' IN result.txt
-DROP LINES MATCHING '"start":' IN result.txt
-DROP LINES MATCHING '"stop":' IN result.txt
-DROP LINES MATCHING '"threadId":' IN result.txt
+DROP LINES CONTAINING '"duration":' IN result.txt
+DROP LINES CONTAINING '"start":' IN result.txt
+DROP LINES CONTAINING '"stop":' IN result.txt
+DROP LINES CONTAINING '"threadId":' IN result.txt
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF

--- a/test/test/fail_rdf_resolution_json.clitest
+++ b/test/test/fail_rdf_resolution_json.clitest
@@ -41,10 +41,10 @@ RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EX
 COMPARE validated.txt AGAINST silent.txt
 
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
-DROP LINES MATCHING '"duration":' IN result.txt
-DROP LINES MATCHING '"start":' IN result.txt
-DROP LINES MATCHING '"stop":' IN result.txt
-DROP LINES MATCHING '"threadId":' IN result.txt
+DROP LINES CONTAINING '"duration":' IN result.txt
+DROP LINES CONTAINING '"start":' IN result.txt
+DROP LINES CONTAINING '"stop":' IN result.txt
+DROP LINES CONTAINING '"threadId":' IN result.txt
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF

--- a/test/test/fail_tests_empty.clitest
+++ b/test/test/fail_tests_empty.clitest
@@ -32,8 +32,8 @@ RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result
 EXTRACT STDOUT FROM result_1.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_1.txt
-DROP LINES MATCHING '"start":' IN result_1.txt
-DROP LINES MATCHING '"stop":' IN result_1.txt
+DROP LINES CONTAINING '"start":' IN result_1.txt
+DROP LINES CONTAINING '"stop":' IN result_1.txt
 WRITE expected_1.txt UNTIL EOF
 1> {
 1>   "reportFormat": "CTRF",

--- a/test/test/fail_tests_empty_jobs_json.clitest
+++ b/test/test/fail_tests_empty_jobs_json.clitest
@@ -49,14 +49,14 @@ RUN test tests --resolve schema.json --json --jobs 2 STDIN /dev/null IN . INTO r
 EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
-DROP LINES MATCHING '"duration":' IN result_0.txt
-DROP LINES MATCHING '"start":' IN result_0.txt
-DROP LINES MATCHING '"stop":' IN result_0.txt
-DROP LINES MATCHING '"threadId":' IN result_0.txt
-DROP LINES MATCHING '"duration":' IN result_0.txt
-DROP LINES MATCHING '"start":' IN result_0.txt
-DROP LINES MATCHING '"stop":' IN result_0.txt
-DROP LINES MATCHING '"threadId":' IN result_0.txt
+DROP LINES CONTAINING '"duration":' IN result_0.txt
+DROP LINES CONTAINING '"start":' IN result_0.txt
+DROP LINES CONTAINING '"stop":' IN result_0.txt
+DROP LINES CONTAINING '"threadId":' IN result_0.txt
+DROP LINES CONTAINING '"duration":' IN result_0.txt
+DROP LINES CONTAINING '"start":' IN result_0.txt
+DROP LINES CONTAINING '"stop":' IN result_0.txt
+DROP LINES CONTAINING '"threadId":' IN result_0.txt
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
@@ -112,14 +112,14 @@ RUN test tests --resolve schema.json --json --jobs 1 STDIN /dev/null IN . INTO r
 EXTRACT STDOUT FROM result_2.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_2.txt
-DROP LINES MATCHING '"duration":' IN result_2.txt
-DROP LINES MATCHING '"start":' IN result_2.txt
-DROP LINES MATCHING '"stop":' IN result_2.txt
-DROP LINES MATCHING '"threadId":' IN result_2.txt
-DROP LINES MATCHING '"duration":' IN result_2.txt
-DROP LINES MATCHING '"start":' IN result_2.txt
-DROP LINES MATCHING '"stop":' IN result_2.txt
-DROP LINES MATCHING '"threadId":' IN result_2.txt
+DROP LINES CONTAINING '"duration":' IN result_2.txt
+DROP LINES CONTAINING '"start":' IN result_2.txt
+DROP LINES CONTAINING '"stop":' IN result_2.txt
+DROP LINES CONTAINING '"threadId":' IN result_2.txt
+DROP LINES CONTAINING '"duration":' IN result_2.txt
+DROP LINES CONTAINING '"start":' IN result_2.txt
+DROP LINES CONTAINING '"stop":' IN result_2.txt
+DROP LINES CONTAINING '"threadId":' IN result_2.txt
 REPLACE $CWD WITH '[CWD]' IN result_2.txt
 
 WRITE expected_2.txt UNTIL EOF

--- a/test/test/fail_true_single_resolve_json.clitest
+++ b/test/test/fail_true_single_resolve_json.clitest
@@ -32,10 +32,10 @@ RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EX
 COMPARE validated.txt AGAINST silent.txt
 
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
-DROP LINES MATCHING '"duration":' IN result.txt
-DROP LINES MATCHING '"start":' IN result.txt
-DROP LINES MATCHING '"stop":' IN result.txt
-DROP LINES MATCHING '"threadId":' IN result.txt
+DROP LINES CONTAINING '"duration":' IN result.txt
+DROP LINES CONTAINING '"start":' IN result.txt
+DROP LINES CONTAINING '"stop":' IN result.txt
+DROP LINES CONTAINING '"threadId":' IN result.txt
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF

--- a/test/test/pass_file_target_without_resolve_json.clitest
+++ b/test/test/pass_file_target_without_resolve_json.clitest
@@ -30,10 +30,10 @@ RUN test this/is/a/very/very/very/long/path/test.json --json STDIN /dev/null IN 
 EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
-DROP LINES MATCHING '"duration":' IN result_0.txt
-DROP LINES MATCHING '"start":' IN result_0.txt
-DROP LINES MATCHING '"stop":' IN result_0.txt
-DROP LINES MATCHING '"threadId":' IN result_0.txt
+DROP LINES CONTAINING '"duration":' IN result_0.txt
+DROP LINES CONTAINING '"start":' IN result_0.txt
+DROP LINES CONTAINING '"stop":' IN result_0.txt
+DROP LINES CONTAINING '"threadId":' IN result_0.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 

--- a/test/test/pass_jobs_verbose.clitest
+++ b/test/test/pass_jobs_verbose.clitest
@@ -39,7 +39,7 @@ WRITE expected_0.txt UNTIL EOF
 2> Using parallelism: [CORES]
 EOF
 
-REPLACE '\[CORES\]' WITH $CORES IN expected_0.txt
+REPLACE '[CORES]' WITH $CORES IN expected_0.txt
 
 COMPARE result_0.txt AGAINST expected_0.txt
 

--- a/test/test/pass_multi_jobs_json.clitest
+++ b/test/test/pass_multi_jobs_json.clitest
@@ -67,14 +67,14 @@ RUN test tests --resolve schema.json --json --jobs 2 STDIN /dev/null IN . INTO r
 EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
-DROP LINES MATCHING '"duration":' IN result_0.txt
-DROP LINES MATCHING '"start":' IN result_0.txt
-DROP LINES MATCHING '"stop":' IN result_0.txt
-DROP LINES MATCHING '"threadId":' IN result_0.txt
-DROP LINES MATCHING '"duration":' IN result_0.txt
-DROP LINES MATCHING '"start":' IN result_0.txt
-DROP LINES MATCHING '"stop":' IN result_0.txt
-DROP LINES MATCHING '"threadId":' IN result_0.txt
+DROP LINES CONTAINING '"duration":' IN result_0.txt
+DROP LINES CONTAINING '"start":' IN result_0.txt
+DROP LINES CONTAINING '"stop":' IN result_0.txt
+DROP LINES CONTAINING '"threadId":' IN result_0.txt
+DROP LINES CONTAINING '"duration":' IN result_0.txt
+DROP LINES CONTAINING '"start":' IN result_0.txt
+DROP LINES CONTAINING '"stop":' IN result_0.txt
+DROP LINES CONTAINING '"threadId":' IN result_0.txt
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
@@ -149,14 +149,14 @@ RUN test tests --resolve schema.json --json --jobs 1 STDIN /dev/null IN . INTO r
 EXTRACT STDOUT FROM result_2.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_2.txt
-DROP LINES MATCHING '"duration":' IN result_2.txt
-DROP LINES MATCHING '"start":' IN result_2.txt
-DROP LINES MATCHING '"stop":' IN result_2.txt
-DROP LINES MATCHING '"threadId":' IN result_2.txt
-DROP LINES MATCHING '"duration":' IN result_2.txt
-DROP LINES MATCHING '"start":' IN result_2.txt
-DROP LINES MATCHING '"stop":' IN result_2.txt
-DROP LINES MATCHING '"threadId":' IN result_2.txt
+DROP LINES CONTAINING '"duration":' IN result_2.txt
+DROP LINES CONTAINING '"start":' IN result_2.txt
+DROP LINES CONTAINING '"stop":' IN result_2.txt
+DROP LINES CONTAINING '"threadId":' IN result_2.txt
+DROP LINES CONTAINING '"duration":' IN result_2.txt
+DROP LINES CONTAINING '"start":' IN result_2.txt
+DROP LINES CONTAINING '"stop":' IN result_2.txt
+DROP LINES CONTAINING '"threadId":' IN result_2.txt
 REPLACE $CWD WITH '[CWD]' IN result_2.txt
 
 WRITE expected_2.txt UNTIL EOF

--- a/test/test/pass_multi_target_resolve_json.clitest
+++ b/test/test/pass_multi_target_resolve_json.clitest
@@ -42,10 +42,10 @@ RUN test test.json --resolve schemas --json STDIN /dev/null IN . INTO result_0.t
 EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
-DROP LINES MATCHING '"duration":' IN result_0.txt
-DROP LINES MATCHING '"start":' IN result_0.txt
-DROP LINES MATCHING '"stop":' IN result_0.txt
-DROP LINES MATCHING '"threadId":' IN result_0.txt
+DROP LINES CONTAINING '"duration":' IN result_0.txt
+DROP LINES CONTAINING '"start":' IN result_0.txt
+DROP LINES CONTAINING '"stop":' IN result_0.txt
+DROP LINES CONTAINING '"threadId":' IN result_0.txt
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF

--- a/test/test/pass_single_no_description_json.clitest
+++ b/test/test/pass_single_no_description_json.clitest
@@ -23,10 +23,10 @@ RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result
 EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
-DROP LINES MATCHING '"duration":' IN result_0.txt
-DROP LINES MATCHING '"start":' IN result_0.txt
-DROP LINES MATCHING '"stop":' IN result_0.txt
-DROP LINES MATCHING '"threadId":' IN result_0.txt
+DROP LINES CONTAINING '"duration":' IN result_0.txt
+DROP LINES CONTAINING '"start":' IN result_0.txt
+DROP LINES CONTAINING '"stop":' IN result_0.txt
+DROP LINES CONTAINING '"threadId":' IN result_0.txt
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF

--- a/test/test/pass_single_resolve_json.clitest
+++ b/test/test/pass_single_resolve_json.clitest
@@ -29,10 +29,10 @@ RUN test test.json --resolve schema.json --json STDIN /dev/null IN . INTO result
 EXTRACT STDOUT FROM result_0.txt INTO output.json
 
 REPLACE $VERSION WITH '[VERSION]' IN result_0.txt
-DROP LINES MATCHING '"duration":' IN result_0.txt
-DROP LINES MATCHING '"start":' IN result_0.txt
-DROP LINES MATCHING '"stop":' IN result_0.txt
-DROP LINES MATCHING '"threadId":' IN result_0.txt
+DROP LINES CONTAINING '"duration":' IN result_0.txt
+DROP LINES CONTAINING '"start":' IN result_0.txt
+DROP LINES CONTAINING '"stop":' IN result_0.txt
+DROP LINES CONTAINING '"threadId":' IN result_0.txt
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF

--- a/test/validate/fail_benchmark.clitest
+++ b/test/validate/fail_benchmark.clitest
@@ -20,7 +20,7 @@ EOF
 RUN validate schema.json instance.json --benchmark STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
-REPLACE '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
+REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 1> instance.json: FAIL [TIMING]

--- a/test/validate/pass_benchmark.clitest
+++ b/test/validate/pass_benchmark.clitest
@@ -18,7 +18,7 @@ EOF
 
 RUN validate schema.json instance.json --benchmark STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
+REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 1> instance.json: PASS [TIMING]

--- a/test/validate/pass_benchmark_loop.clitest
+++ b/test/validate/pass_benchmark_loop.clitest
@@ -18,7 +18,7 @@ EOF
 
 RUN validate schema.json instance.json --benchmark --loop 1000 STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
+REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 1> instance.json: PASS [TIMING]

--- a/test/validate/pass_benchmark_loop_jsonl.clitest
+++ b/test/validate/pass_benchmark_loop_jsonl.clitest
@@ -16,7 +16,7 @@ EOF
 RUN validate schema.json instance.jsonl --benchmark --loop 1000 STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
-REPLACE '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
+REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 1> [CWD]/instance.jsonl[1]: PASS [TIMING]

--- a/test/validate/pass_stdin_instance_benchmark.clitest
+++ b/test/validate/pass_stdin_instance_benchmark.clitest
@@ -17,7 +17,7 @@ EOF
 RUN validate schema.json - --benchmark STDIN stdin_0 IN . INTO result.txt EXPECTING 0
 
 // Timings vary per run, so normalise every decimal number
-REPLACE '[0-9]+\.[0-9]+' WITH '<FLOAT>' IN result.txt
+REPLACE MATCHING '[0-9]+\.[0-9]+' WITH '<FLOAT>' IN result.txt
 
 WRITE expected.txt UNTIL EOF
 1> tag:sourcemeta.com,2026:jsonschema/stdin: PASS <FLOAT> +- <FLOAT> us (<FLOAT>)


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

