### PR TITLE
Clarify non-copy-left licensing option for enterprises

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -297,5 +297,6 @@ yours. This is the same way that managing your proprietary code with
 refer to the full [license](./LICENSE).
 
 *If you still require a non-copyleft license to run this tool inside your
-organisation, reach out to
-[hello@sourcemeta.com](mailto:hello@sourcemeta.com).*
+organisation, see our [licensing page](https://www.sourcemeta.com/licensing/)
+and reach out to [hello@sourcemeta.com](mailto:hello@sourcemeta.com) to discuss
+further*

--- a/README.markdown
+++ b/README.markdown
@@ -295,3 +295,7 @@ yours. This is the same way that managing your proprietary code with
 [Git](https://git-scm.com) does not make your code subject to the
 [GPL](https://www.gnu.org/licenses/gpl-3.0.en.html). For any other use, please
 refer to the full [license](./LICENSE).
+
+*If you still require a non-copyleft license to run this tool inside your
+organisation, reach out to
+[hello@sourcemeta.com](mailto:hello@sourcemeta.com).*


### PR DESCRIPTION
We came across some enterprises that are, by company policy, totally
prohibited from making use of AGPL software, even if in the case of a
CLI like this, should not trigger any copyleft requirements under normal
use.

This clarifies we are still able to cater to that audience if really
needed, as the contribution guide outlines.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

