### PR TITLE
Make use of `SchemaFrame::IdentifierMode::Fallback` in `inspect`

### DIFF
--- a/src/command_inspect.cc
+++ b/src/command_inspect.cc
@@ -204,18 +204,11 @@ auto sourcemeta::jsonschema::inspect(const sourcemeta::core::Options &options)
   try {
     const auto &custom_resolver{
         resolver(options, options.contains("http"), dialect, configuration)};
-    const auto identifier{
-        sourcemeta::blaze::identify(schema, custom_resolver, dialect)};
-
-    frame.analyse(
-        schema, sourcemeta::blaze::schema_walker, custom_resolver, dialect,
-
-        // Only use the file-based URI if the schema has no
-        // identifier, as otherwise we make the output unnecessarily
-        // hard when it comes to debugging schemas
-        !identifier.empty() ? ""
-                            : sourcemeta::jsonschema::default_id(
-                                  schema_resolution_base, schema_from_stdin));
+    frame.analyse(schema, sourcemeta::blaze::schema_walker, custom_resolver,
+                  dialect,
+                  sourcemeta::jsonschema::default_id(schema_resolution_base,
+                                                     schema_from_stdin),
+                  sourcemeta::blaze::SchemaFrame::IdentifierMode::Fallback);
   } catch (const sourcemeta::blaze::SchemaKeywordError &error) {
     throw sourcemeta::core::FileError<sourcemeta::blaze::SchemaKeywordError>(
         schema_resolution_base, error);


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

