### PR TITLE
Print a summary line at the end of `validate` and `metaschema` runs

### DIFF
--- a/src/command_metaschema.cc
+++ b/src/command_metaschema.cc
@@ -55,12 +55,13 @@ auto sourcemeta::jsonschema::metaschema(
   const auto trace{options.contains("trace")};
   const auto json_output{options.contains("json")};
 
-  bool result{true};
+  ValidationSummary summary;
   sourcemeta::blaze::Evaluator evaluator;
 
   std::map<std::string, sourcemeta::blaze::Template> cache;
 
   for (const auto &entry : for_each_json(options, InputRequirement::NonEmpty)) {
+    summary.validated += 1;
     if (!entry.second.is_object() && !entry.second.is_boolean()) {
       throw NotSchemaError{entry.from_stdin ? stdin_path()
                                             : entry.resolution_base};
@@ -111,8 +112,10 @@ auto sourcemeta::jsonschema::metaschema(
         sourcemeta::blaze::TraceOutput output{
             cache.at(std::string{dialect}),
             trace_callback(entry.positions, std::cout)};
-        result = evaluator.validate(cache.at(std::string{dialect}),
-                                    entry.second, std::ref(output));
+        if (!evaluator.validate(cache.at(std::string{dialect}), entry.second,
+                                std::ref(output))) {
+          summary.failed += 1;
+        }
       } else if (json_output) {
         // Otherwise its impossible to correlate the output
         // when validating i.e. a directory of schemas
@@ -124,7 +127,7 @@ auto sourcemeta::jsonschema::metaschema(
         assert(output.defines("valid"));
         assert(output.at("valid").is_boolean());
         if (!output.at("valid").to_boolean()) {
-          result = false;
+          summary.failed += 1;
         }
 
         sourcemeta::core::prettify(output, std::cout);
@@ -138,7 +141,7 @@ auto sourcemeta::jsonschema::metaschema(
         } else {
           std::cerr << "fail: " << entry.first << "\n";
           print(output, entry.positions, std::cerr);
-          result = false;
+          summary.failed += 1;
         }
       }
     } catch (const sourcemeta::blaze::SchemaKeywordError &error) {
@@ -196,7 +199,11 @@ auto sourcemeta::jsonschema::metaschema(
     }
   }
 
-  if (!result) {
+  if (!json_output && !trace) {
+    print_summary(summary, options, std::cerr);
+  }
+
+  if (summary.failed > 0) {
     throw Fail{EXIT_EXPECTED_FAILURE};
   }
 }

--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -11,7 +11,6 @@
 
 #include <chrono>      // std::chrono
 #include <cmath>       // std::sqrt
-#include <cstddef>     // std::size_t
 #include <iostream>    // std::cerr
 #include <string>      // std::string
 #include <string_view> // std::string_view
@@ -145,13 +144,14 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
                    bool benchmark, std::uint64_t benchmark_loop, bool trace,
                    bool fast_mode, bool json_output, bool continue_on_error,
                    const std::filesystem::path &schema_resolution_base,
-                   const sourcemeta::core::Options &options, bool &result)
-    -> bool {
+                   const sourcemeta::core::Options &options,
+                   sourcemeta::jsonschema::ValidationSummary &summary) -> bool {
   sourcemeta::blaze::SimpleOutput output{entry.second};
   sourcemeta::blaze::TraceOutput trace_output{
       schema_template,
       sourcemeta::jsonschema::trace_callback(entry.positions, std::cout)};
   bool subresult{true};
+  summary.validated += 1;
   if (benchmark) {
     subresult = run_loop(evaluator, schema_template, entry.second, entry.first,
                          entry.multidocument
@@ -159,7 +159,7 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
                              : static_cast<std::int64_t>(-1),
                          benchmark_loop);
     if (!subresult) {
-      result = false;
+      summary.failed += 1;
     }
   } else if (trace) {
     subresult = evaluator.validate(schema_template, entry.second,
@@ -176,7 +176,9 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
   }
 
   if (trace) {
-    result = result && subresult;
+    if (!subresult) {
+      summary.failed += 1;
+    }
   } else if (json_output) {
     if (!entry.multidocument) {
       std::cerr << entry.first << "\n";
@@ -192,13 +194,13 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
     sourcemeta::core::prettify(suboutput, std::cout);
     std::cout << "\n";
     if (!suboutput.at("valid").to_boolean()) {
-      result = false;
+      summary.failed += 1;
       if (!continue_on_error) {
         return false;
       }
     }
   } else if (subresult) {
-    if (continue_on_error && entry.multidocument && !result) {
+    if (continue_on_error && entry.multidocument && summary.failed > 0) {
       sourcemeta::jsonschema::LOG_VERBOSE(options) << "\n";
     }
     sourcemeta::jsonschema::LOG_VERBOSE(options) << "ok: " << entry.first;
@@ -211,7 +213,7 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
         << sourcemeta::jsonschema::stdin_path_string(schema_resolution_base)
         << "\n";
   } else {
-    if (continue_on_error && entry.multidocument && !result) {
+    if (continue_on_error && entry.multidocument && summary.failed > 0) {
       std::cerr << "\n";
     }
     std::cerr << "fail: " << entry.first;
@@ -223,7 +225,7 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
       std::cerr << "\n";
     }
     sourcemeta::jsonschema::print(output, entry.positions, std::cerr);
-    result = false;
+    summary.failed += 1;
     if (!continue_on_error) {
       return false;
     }
@@ -334,7 +336,7 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
 
   sourcemeta::blaze::Evaluator evaluator;
 
-  bool result{true};
+  ValidationSummary summary;
 
   std::vector<std::string_view> instance_arguments;
   if (options.positional().size() > 1) {
@@ -373,13 +375,12 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
       if (!process_entry(entry, evaluator, schema_template, benchmark,
                          benchmark_loop, trace, fast_mode, json_output,
                          continue_on_error, schema_resolution_base, options,
-                         result)) {
+                         summary)) {
         break;
       }
     }
   } else {
     bool proceed{true};
-    std::size_t instance_count{0};
     for (const auto &instance_path_view : instance_arguments) {
       const std::filesystem::path instance_path{instance_path_view};
       if (trace && (instance_path.extension() == ".jsonl" ||
@@ -407,11 +408,10 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
           instance_path.extension() == ".yaml" ||
           instance_path.extension() == ".yml") {
         for (const auto &entry : for_each_json({instance_path_view}, options)) {
-          instance_count += 1;
           if (!process_entry(entry, evaluator, schema_template, benchmark,
                              benchmark_loop, trace, fast_mode, json_output,
                              continue_on_error, schema_resolution_base, options,
-                             result)) {
+                             summary)) {
             proceed = false;
             break;
           }
@@ -430,7 +430,7 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
           }
           return sourcemeta::core::read_yaml_or_json(instance_path);
         }()};
-        instance_count += 1;
+        summary.validated += 1;
         sourcemeta::blaze::SimpleOutput output{instance};
         sourcemeta::blaze::TraceOutput trace_output{
             schema_template, trace_callback(tracker, std::cout)};
@@ -439,9 +439,6 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
           subresult = run_loop(evaluator, schema_template, instance,
                                instance_path.generic_string(),
                                static_cast<std::int64_t>(-1), benchmark_loop);
-          if (!subresult) {
-            result = false;
-          }
         } else if (trace) {
           subresult = evaluator.validate(schema_template, instance,
                                          std::ref(trace_output));
@@ -453,7 +450,9 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
         }
 
         if (trace) {
-          result = result && subresult;
+          if (!subresult) {
+            summary.failed += 1;
+          }
         } else if (json_output) {
           const auto suboutput{sourcemeta::blaze::standard(
               evaluator, schema_template, instance,
@@ -464,7 +463,7 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
           assert(suboutput.defines("valid"));
           assert(suboutput.at("valid").is_boolean());
           if (!suboutput.at("valid").to_boolean()) {
-            result = false;
+            summary.failed += 1;
             proceed = continue_on_error;
           }
 
@@ -483,7 +482,7 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
                            .generic_string()
                     << "\n";
           print(output, tracker, std::cerr);
-          result = false;
+          summary.failed += 1;
           proceed = continue_on_error;
         }
       }
@@ -493,13 +492,17 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
       }
     }
 
-    if (instance_count == 0) {
+    if (summary.validated == 0) {
       throw sourcemeta::core::FileError<NoInputFilesError>(
           std::filesystem::path{instance_arguments.front()});
     }
   }
 
-  if (!result) {
+  if (!json_output && !trace && !benchmark) {
+    print_summary(summary, options, std::cerr);
+  }
+
+  if (summary.failed > 0) {
     throw Fail{EXIT_EXPECTED_FAILURE};
   }
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,6 +18,7 @@
 
 #include <algorithm>   // std::max, std::ranges::all_of
 #include <cctype>      // std::isdigit
+#include <cstddef>     // std::size_t
 #include <filesystem>  // std::filesystem::path
 #include <memory>      // std::make_shared
 #include <optional>    // std::optional
@@ -443,6 +444,24 @@ inline auto print(const Entries &output,
     sourcemeta::core::stringify(entry.evaluate_path, stream);
     stream << "\"\n";
   }
+}
+
+struct ValidationSummary {
+  std::size_t validated{0};
+  std::size_t failed{0};
+};
+
+inline auto print_summary(const ValidationSummary &summary,
+                          const sourcemeta::core::Options &options,
+                          std::ostream &stream) -> void {
+  if (summary.failed > 0 || options.contains("verbose") ||
+      options.contains("debug")) {
+    stream << "\n";
+  }
+
+  stream << summary.validated << " validated, "
+         << (summary.validated - summary.failed) << " passed, "
+         << summary.failed << " failed\n";
 }
 
 inline auto

--- a/test/ci/pass_install_add_http.clitest
+++ b/test/ci/pass_install_add_http.clitest
@@ -66,6 +66,7 @@ EOF
 RUN validate $CWD/project/vendor/identifier.json $CWD/instance.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/ci/pass_install_http.clitest
+++ b/test/ci/pass_install_http.clitest
@@ -241,6 +241,7 @@ EOF
 RUN validate $CWD/project/vendor/response.json $CWD/instance.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/ci/pass_validate_fuse.sh
+++ b/test/ci/pass_validate_fuse.sh
@@ -35,7 +35,8 @@ EOF
 
 bindfs --no-allow-other "$TMP" "$FUSE_MOUNT"
 
-"$1" validate --verbose "$FUSE_MOUNT/level1/level2/level3/schema.json" "$FUSE_MOUNT/instance.json" 2> "$TMP/output.txt"
+"$1" validate --verbose "$FUSE_MOUNT/level1/level2/level3/schema.json" \
+  "$FUSE_MOUNT/instance.json" > "$TMP/output.txt" 2>&1
 
 cat << EOF > "$TMP/expected.txt"
 ok: $(realpath "$FUSE_MOUNT")/instance.json

--- a/test/ci/pass_validate_fuse.sh
+++ b/test/ci/pass_validate_fuse.sh
@@ -40,6 +40,8 @@ bindfs --no-allow-other "$TMP" "$FUSE_MOUNT"
 cat << EOF > "$TMP/expected.txt"
 ok: $(realpath "$FUSE_MOUNT")/instance.json
   matches $(realpath "$FUSE_MOUNT")/level1/level2/level3/schema.json
+
+1 validated, 1 passed, 0 failed
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/ci/pass_validate_http.clitest
+++ b/test/ci/pass_validate_http.clitest
@@ -16,6 +16,7 @@ EOF
 RUN validate schema.json instance.json --http STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/ci/pass_validate_http_header_auth.sh
+++ b/test/ci/pass_validate_http_header_auth.sh
@@ -51,6 +51,7 @@ EOF
   > "$TMP/output.txt" 2>&1
 
 cat << 'EOF' > "$TMP/expected.txt"
+1 validated, 1 passed, 0 failed
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/compile/pass_patternproperties.clitest
+++ b/test/compile/pass_patternproperties.clitest
@@ -22,7 +22,8 @@ WRITE instance_invalid.json UNTIL EOF
 { "foo-bar": 1 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN compile schema.json STDIN /dev/null IN . INTO compiled.txt EXPECTING 0
@@ -31,7 +32,7 @@ EXTRACT STDOUT FROM compiled.txt INTO template.json
 
 RUN validate --template template.json schema.json instance.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 
-COMPARE validated.txt AGAINST silent.txt
+COMPARE validated.txt AGAINST expected.txt
 
 // Validation failure
 RUN validate --template template.json schema.json instance_invalid.json STDIN /dev/null IN . INTO validated_invalid.txt EXPECTING 2
@@ -47,6 +48,8 @@ WRITE expected_invalid.txt UNTIL EOF
 2>   The object properties that match the regular expression "[\-]" were expected to validate against the defined pattern property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/patternProperties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE validated_invalid.txt AGAINST expected_invalid.txt

--- a/test/install/pass_resolver_official_schema.clitest
+++ b/test/install/pass_resolver_official_schema.clitest
@@ -60,6 +60,7 @@ REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
 REPLACE $CWD WITH '[CWD]' IN result_1.txt
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/metaschema/fail_directory.clitest
+++ b/test/metaschema/fail_directory.clitest
@@ -39,6 +39,8 @@ WRITE expected.txt UNTIL EOF
 2>   The object value was expected to validate against the 33 defined properties subschemas
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/fail_format_assertion_flag.clitest
+++ b/test/metaschema/fail_format_assertion_flag.clitest
@@ -29,6 +29,8 @@ WRITE expected.txt UNTIL EOF
 2>   The object value was expected to validate against the 7 given subschemas
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/allOf"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/fail_single.clitest
+++ b/test/metaschema/fail_single.clitest
@@ -30,6 +30,8 @@ WRITE expected.txt UNTIL EOF
 2>   The object value was expected to validate against the 33 defined properties subschemas
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/fail_stdin_metaschema.clitest
+++ b/test/metaschema/fail_stdin_metaschema.clitest
@@ -26,6 +26,8 @@ WRITE expected.txt UNTIL EOF
 2>   The object value was expected to validate against the 33 defined properties subschemas
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/fail_yaml.clitest
+++ b/test/metaschema/fail_yaml.clitest
@@ -26,6 +26,8 @@ WRITE expected.txt UNTIL EOF
 2>   The object value was expected to validate against the 33 defined properties subschemas
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_2019_09_http.clitest
+++ b/test/metaschema/pass_2019_09_http.clitest
@@ -12,9 +12,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_2020_12.clitest
+++ b/test/metaschema/pass_2020_12.clitest
@@ -12,9 +12,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_2020_12_default_dialect.clitest
+++ b/test/metaschema/pass_2020_12_default_dialect.clitest
@@ -9,9 +9,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema --default-dialect https://json-schema.org/draft/2020-12/schema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_2020_12_default_dialect_config.clitest
+++ b/test/metaschema/pass_2020_12_default_dialect_config.clitest
@@ -25,6 +25,8 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .yml
 2> ok: [CWD]/schema.json
 2>   matches https://json-schema.org/draft/2020-12/schema
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_2020_12_default_dialect_config_relative.clitest
+++ b/test/metaschema/pass_2020_12_default_dialect_config_relative.clitest
@@ -25,6 +25,8 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .yml
 2> ok: [CWD]/schema.json
 2>   matches https://json-schema.org/draft/2020-12/schema
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_2020_12_http.clitest
+++ b/test/metaschema/pass_2020_12_http.clitest
@@ -12,9 +12,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_2020_12_with_fragment.clitest
+++ b/test/metaschema/pass_2020_12_with_fragment.clitest
@@ -12,9 +12,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_bundled_metaschema.clitest
+++ b/test/metaschema/pass_bundled_metaschema.clitest
@@ -17,9 +17,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_config_ignore.clitest
+++ b/test/metaschema/pass_config_ignore.clitest
@@ -22,9 +22,10 @@ WRITE jsonschema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_config_path.clitest
+++ b/test/metaschema/pass_config_path.clitest
@@ -25,6 +25,8 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .yml
 2> ok: [CWD]/foo/schema.json
 2>   matches http://json-schema.org/draft-04/schema#
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_config_path_debug.clitest
+++ b/test/metaschema/pass_config_path_debug.clitest
@@ -26,6 +26,8 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .yml
 2> ok: [CWD]/foo/schema.json
 2>   matches http://json-schema.org/draft-04/schema#
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_configuration_option.clitest
+++ b/test/metaschema/pass_configuration_option.clitest
@@ -28,6 +28,8 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .yml
 2> ok: [CWD]/schema.json
 2>   matches https://json-schema.org/draft/2020-12/schema
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_custom_config_resolve.clitest
+++ b/test/metaschema/pass_custom_config_resolve.clitest
@@ -43,6 +43,8 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .yml
 2> ok: [CWD]/schema.json
 2>   matches https://example.com/meta
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_custom_extension_json.clitest
+++ b/test/metaschema/pass_custom_extension_json.clitest
@@ -6,9 +6,10 @@ WRITE schema.custom UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.custom STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_custom_extension_yaml.clitest
+++ b/test/metaschema/pass_custom_extension_yaml.clitest
@@ -4,9 +4,10 @@ $schema: https://json-schema.org/draft/2020-12/schema
 type: string
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.custom STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_cwd.clitest
+++ b/test/metaschema/pass_cwd.clitest
@@ -26,6 +26,8 @@ WRITE expected.txt UNTIL EOF
 2>   matches http://json-schema.org/draft-04/schema#
 2> ok: [CWD]/schema_2.json
 2>   matches http://json-schema.org/draft-04/schema#
+2>
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_cwd_config_no_path.clitest
+++ b/test/metaschema/pass_cwd_config_no_path.clitest
@@ -28,6 +28,8 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .yml
 2> ok: [CWD]/schema.json
 2>   matches http://json-schema.org/draft-04/schema#
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_draft3_https.clitest
+++ b/test/metaschema/pass_draft3_https.clitest
@@ -7,9 +7,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_draft4_https.clitest
+++ b/test/metaschema/pass_draft4_https.clitest
@@ -7,9 +7,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_draft6_https.clitest
+++ b/test/metaschema/pass_draft6_https.clitest
@@ -7,9 +7,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_draft7_https.clitest
+++ b/test/metaschema/pass_draft7_https.clitest
@@ -7,9 +7,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_draft7_without_fragment.clitest
+++ b/test/metaschema/pass_draft7_without_fragment.clitest
@@ -7,9 +7,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_extension_empty_json.clitest
+++ b/test/metaschema/pass_extension_empty_json.clitest
@@ -35,6 +35,8 @@ WRITE expected.txt UNTIL EOF
 2>   matches http://json-schema.org/draft-04/schema#
 2> ok: [CWD]/schemas/schema2
 2>   matches http://json-schema.org/draft-04/schema#
+2>
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_extension_empty_yaml.clitest
+++ b/test/metaschema/pass_extension_empty_yaml.clitest
@@ -29,6 +29,8 @@ WRITE expected.txt UNTIL EOF
 2>   matches http://json-schema.org/draft-04/schema#
 2> ok: [CWD]/schemas/schema2
 2>   matches http://json-schema.org/draft-04/schema#
+2>
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_many_one_empty_directory.clitest
+++ b/test/metaschema/pass_many_one_empty_directory.clitest
@@ -17,6 +17,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/schemas/schema.json
 2>   matches http://json-schema.org/draft-04/schema#
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/metaschema/pass_single.clitest
+++ b/test/metaschema/pass_single.clitest
@@ -7,9 +7,10 @@ WRITE schema.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_stdin_metaschema.clitest
+++ b/test/metaschema/pass_stdin_metaschema.clitest
@@ -5,9 +5,10 @@ WRITE input.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema - STDIN input.json IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_stdin_metaschema_verbose.clitest
+++ b/test/metaschema/pass_stdin_metaschema_verbose.clitest
@@ -10,6 +10,8 @@ RUN metaschema - --verbose STDIN input.json IN . INTO result.txt EXPECTING 0
 WRITE expected.txt UNTIL EOF
 2> ok: tag:sourcemeta.com,2026:jsonschema/stdin
 2>   matches https://json-schema.org/draft/2020-12/schema
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_without_extension_json.clitest
+++ b/test/metaschema/pass_without_extension_json.clitest
@@ -7,9 +7,10 @@ WRITE schema UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_without_extension_yaml.clitest
+++ b/test/metaschema/pass_without_extension_yaml.clitest
@@ -5,9 +5,10 @@ description: Test schema
 type: string
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE expected.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 RUN metaschema schema STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-COMPARE result.txt AGAINST silent.txt
+COMPARE result.txt AGAINST expected.txt

--- a/test/test/fail_false_single_resolve_json.clitest
+++ b/test/test/fail_false_single_resolve_json.clitest
@@ -70,6 +70,7 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN validate $CTRF_SCHEMA output.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/test/fail_multi_jobs_json.clitest
+++ b/test/test/fail_multi_jobs_json.clitest
@@ -65,7 +65,8 @@ WRITE tests/4.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE summary.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 // The shell original ran this five times to shake out ordering flakes.
@@ -77,7 +78,7 @@ EXTRACT STDOUT FROM result.txt INTO report.json
 
 RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 
-COMPARE validated.txt AGAINST silent.txt
+COMPARE validated.txt AGAINST summary.txt
 
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
 DROP LINES CONTAINING '"duration":' IN result.txt

--- a/test/test/fail_multi_target_resolve.clitest
+++ b/test/test/fail_multi_target_resolve.clitest
@@ -111,6 +111,7 @@ COMPARE result_1.txt AGAINST expected_1.txt
 RUN validate $CTRF_SCHEMA output.json STDIN /dev/null IN . INTO result_2.txt EXPECTING 0
 
 WRITE expected_2.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_2.txt AGAINST expected_2.txt

--- a/test/test/fail_rdf_invalid_instance_json.clitest
+++ b/test/test/fail_rdf_invalid_instance_json.clitest
@@ -24,7 +24,8 @@ WRITE test.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE summary.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 // Test assertion failure
@@ -34,7 +35,7 @@ EXTRACT STDOUT FROM result.txt INTO report.json
 
 RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 
-COMPARE validated.txt AGAINST silent.txt
+COMPARE validated.txt AGAINST summary.txt
 
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
 DROP LINES CONTAINING '"duration":' IN result.txt

--- a/test/test/fail_rdf_mismatch_json.clitest
+++ b/test/test/fail_rdf_mismatch_json.clitest
@@ -23,7 +23,8 @@ WRITE test.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE summary.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 // Test assertion failure
@@ -33,7 +34,7 @@ EXTRACT STDOUT FROM result.txt INTO report.json
 
 RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 
-COMPARE validated.txt AGAINST silent.txt
+COMPARE validated.txt AGAINST summary.txt
 
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
 DROP LINES CONTAINING '"duration":' IN result.txt

--- a/test/test/fail_rdf_resolution_json.clitest
+++ b/test/test/fail_rdf_resolution_json.clitest
@@ -28,7 +28,8 @@ WRITE test.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE summary.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 // Test assertion failure
@@ -38,7 +39,7 @@ EXTRACT STDOUT FROM result.txt INTO report.json
 
 RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 
-COMPARE validated.txt AGAINST silent.txt
+COMPARE validated.txt AGAINST summary.txt
 
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
 DROP LINES CONTAINING '"duration":' IN result.txt

--- a/test/test/fail_tests_empty.clitest
+++ b/test/test/fail_tests_empty.clitest
@@ -61,6 +61,7 @@ COMPARE result_1.txt AGAINST expected_1.txt
 RUN validate $CTRF_SCHEMA output.json STDIN /dev/null IN . INTO result_2.txt EXPECTING 0
 
 WRITE expected_2.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_2.txt AGAINST expected_2.txt

--- a/test/test/fail_tests_empty_jobs_json.clitest
+++ b/test/test/fail_tests_empty_jobs_json.clitest
@@ -170,11 +170,13 @@ COMPARE result_2.txt AGAINST expected_2.txt
 RUN validate $CTRF_SCHEMA output.json STDIN /dev/null IN . INTO result_3.txt EXPECTING 0
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt
 
 WRITE expected_3.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_3.txt AGAINST expected_3.txt

--- a/test/test/fail_true_single_resolve_json.clitest
+++ b/test/test/fail_true_single_resolve_json.clitest
@@ -19,7 +19,8 @@ WRITE test.json UNTIL EOF
 }
 EOF
 
-WRITE silent.txt UNTIL EOF
+WRITE summary.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 // Test assertion failure
@@ -29,7 +30,7 @@ EXTRACT STDOUT FROM result.txt INTO report.json
 
 RUN validate $CTRF_SCHEMA report.json STDIN /dev/null IN . INTO validated.txt EXPECTING 0
 
-COMPARE validated.txt AGAINST silent.txt
+COMPARE validated.txt AGAINST summary.txt
 
 REPLACE $VERSION WITH '[VERSION]' IN result.txt
 DROP LINES CONTAINING '"duration":' IN result.txt

--- a/test/test/pass_file_target_without_resolve_json.clitest
+++ b/test/test/pass_file_target_without_resolve_json.clitest
@@ -89,6 +89,7 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN validate $CTRF_SCHEMA output.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/test/pass_multi_jobs_json.clitest
+++ b/test/test/pass_multi_jobs_json.clitest
@@ -227,11 +227,13 @@ COMPARE result_2.txt AGAINST expected_2.txt
 RUN validate $CTRF_SCHEMA output.json STDIN /dev/null IN . INTO result_3.txt EXPECTING 0
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt
 
 WRITE expected_3.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_3.txt AGAINST expected_3.txt

--- a/test/test/pass_multi_target_resolve_json.clitest
+++ b/test/test/pass_multi_target_resolve_json.clitest
@@ -116,6 +116,7 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN validate $CTRF_SCHEMA output.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/test/pass_single_no_description_json.clitest
+++ b/test/test/pass_single_no_description_json.clitest
@@ -67,6 +67,7 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN validate $CTRF_SCHEMA output.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/test/pass_single_resolve_json.clitest
+++ b/test/test/pass_single_resolve_json.clitest
@@ -83,6 +83,7 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN validate $CTRF_SCHEMA output.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/validate/fail_2019_09.clitest
+++ b/test/validate/fail_2019_09.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_2019_09_http.clitest
+++ b/test/validate/fail_2019_09_http.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_2020_12.clitest
+++ b/test/validate/fail_2020_12.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_2020_12_fast.clitest
+++ b/test/validate/fail_2020_12_fast.clitest
@@ -24,6 +24,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> fail: [CWD]/instance.json
 2> error: Schema validation failure
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_2020_12_http.clitest
+++ b/test/validate/fail_2020_12_http.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_2020_12_x_format_assertion.clitest
+++ b/test/validate/fail_2020_12_x_format_assertion.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_boolean_schema_false_default_dialect.clitest
+++ b/test/validate/fail_boolean_schema_false_default_dialect.clitest
@@ -14,6 +14,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> fail: [CWD]/instance.json
 2> error: Schema validation failure
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_directory.clitest
+++ b/test/validate/fail_directory.clitest
@@ -39,6 +39,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the defined properties subschemas
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_directory_continue_verbose.clitest
+++ b/test/validate/fail_directory_continue_verbose.clitest
@@ -38,6 +38,8 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/properties"
 2> ok: [CWD]/instances/instance_2.json
 2>   matches [CWD]/schema.json
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_directory_fast.clitest
+++ b/test/validate/fail_directory_fast.clitest
@@ -30,6 +30,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> fail: [CWD]/instances/instance_2.json
 2> error: Schema validation failure
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_directory_stop_verbose.clitest
+++ b/test/validate/fail_directory_stop_verbose.clitest
@@ -36,6 +36,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_directory_verbose.clitest
+++ b/test/validate/fail_directory_verbose.clitest
@@ -41,6 +41,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the defined properties subschemas
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_draft3.clitest
+++ b/test/validate/fail_draft3.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_draft3_https.clitest
+++ b/test/validate/fail_draft3_https.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_draft4.clitest
+++ b/test/validate/fail_draft4.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_draft4_https.clitest
+++ b/test/validate/fail_draft4_https.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_draft4_x_format_assertion.clitest
+++ b/test/validate/fail_draft4_x_format_assertion.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_draft6.clitest
+++ b/test/validate/fail_draft6.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_draft6_https.clitest
+++ b/test/validate/fail_draft6_https.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_draft7.clitest
+++ b/test/validate/fail_draft7.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_draft7_https.clitest
+++ b/test/validate/fail_draft7_https.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_entrypoint_mismatch.clitest
+++ b/test/validate/fail_entrypoint_mismatch.clitest
@@ -27,6 +27,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The integer value -5 was expected to be greater than or equal to the integer 1
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/minimum"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_format_assertion_flag.clitest
+++ b/test/validate/fail_format_assertion_flag.clitest
@@ -21,6 +21,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The string value "not-an-email" was expected to represent a valid email address
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/format"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_all.clitest
+++ b/test/validate/fail_jsonl_all.clitest
@@ -29,6 +29,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type array but it was of type object
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_all_continue.clitest
+++ b/test/validate/fail_jsonl_all_continue.clitest
@@ -51,6 +51,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type array but it was of type object
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 3 validated, 0 passed, 3 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_all_continue_verbose.clitest
+++ b/test/validate/fail_jsonl_all_continue_verbose.clitest
@@ -52,6 +52,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type array but it was of type object
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 3 validated, 0 passed, 3 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_all_verbose.clitest
+++ b/test/validate/fail_jsonl_all_verbose.clitest
@@ -30,6 +30,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type array but it was of type object
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_continue.clitest
+++ b/test/validate/fail_jsonl_continue.clitest
@@ -40,6 +40,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type object but it was of type integer
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 3 validated, 1 passed, 2 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_continue_verbose.clitest
+++ b/test/validate/fail_jsonl_continue_verbose.clitest
@@ -43,6 +43,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type object but it was of type integer
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 3 validated, 1 passed, 2 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_gz_continue.clitest
+++ b/test/validate/fail_jsonl_gz_continue.clitest
@@ -53,6 +53,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type array but it was of type object
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 3 validated, 0 passed, 3 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_gz_continue_verbose.clitest
+++ b/test/validate/fail_jsonl_gz_continue_verbose.clitest
@@ -54,6 +54,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type array but it was of type object
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 3 validated, 0 passed, 3 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_gz_one.clitest
+++ b/test/validate/fail_jsonl_gz_one.clitest
@@ -33,6 +33,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type object but it was of type array
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_gz_one_verbose.clitest
+++ b/test/validate/fail_jsonl_gz_one_verbose.clitest
@@ -36,6 +36,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type object but it was of type array
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_one.clitest
+++ b/test/validate/fail_jsonl_one.clitest
@@ -31,6 +31,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type object but it was of type array
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_one_continue.clitest
+++ b/test/validate/fail_jsonl_one_continue.clitest
@@ -31,6 +31,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type object but it was of type array
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 3 validated, 2 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_one_continue_verbose.clitest
+++ b/test/validate/fail_jsonl_one_continue_verbose.clitest
@@ -37,6 +37,8 @@ WRITE expected_0.txt UNTIL EOF
 2>
 2> ok: [CWD]/instance.jsonl (entry #3)
 2>   matches [CWD]/schema.json
+2>
+2> 3 validated, 2 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_one_verbose.clitest
+++ b/test/validate/fail_jsonl_one_verbose.clitest
@@ -34,6 +34,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type object but it was of type array
 2>     at instance location ""
 2>     at evaluate path "/type"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_many.clitest
+++ b/test/validate/fail_many.clitest
@@ -38,6 +38,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_many_continue_verbose.clitest
+++ b/test/validate/fail_many_continue_verbose.clitest
@@ -42,6 +42,8 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/properties"
 2> ok: [CWD]/instance_3.json
 2>   matches [CWD]/schema.json
+2>
+2> 3 validated, 2 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_many_verbose.clitest
+++ b/test/validate/fail_many_verbose.clitest
@@ -40,6 +40,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_stdin_instance.clitest
+++ b/test/validate/fail_stdin_instance.clitest
@@ -18,6 +18,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/type"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_stdin_schema_validation.clitest
+++ b/test/validate/fail_stdin_schema_validation.clitest
@@ -21,6 +21,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/type"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_stdin_schema_validation_no_id.clitest
+++ b/test/validate/fail_stdin_schema_validation_no_id.clitest
@@ -20,6 +20,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/type"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_stdin_yaml_input.clitest
+++ b/test/validate/fail_stdin_yaml_input.clitest
@@ -19,6 +19,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type string but it was of type object
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/type"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_yaml.clitest
+++ b/test/validate/fail_yaml.clitest
@@ -24,6 +24,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
+2>
+2> 1 validated, 0 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_yaml_multi_blank_lines.clitest
+++ b/test/validate/fail_yaml_multi_blank_lines.clitest
@@ -39,6 +39,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type object but it was of type array
 2>     at instance location "" (line 6, column 1)
 2>     at evaluate path "/type"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_yaml_multi_one.clitest
+++ b/test/validate/fail_yaml_multi_one.clitest
@@ -34,6 +34,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type object but it was of type array
 2>     at instance location "" (line 4, column 1)
 2>     at evaluate path "/type"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_yaml_multi_one_verbose.clitest
+++ b/test/validate/fail_yaml_multi_one_verbose.clitest
@@ -37,6 +37,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The value was expected to be of type object but it was of type array
 2>     at instance location "" (line 4, column 1)
 2>     at evaluate path "/type"
+2>
+2> 2 validated, 1 passed, 1 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2019_09.clitest
+++ b/test/validate/pass_2019_09.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2019_09_http.clitest
+++ b/test/validate/pass_2019_09_http.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2020_12.clitest
+++ b/test/validate/pass_2020_12.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2020_12_default_dialect.clitest
+++ b/test/validate/pass_2020_12_default_dialect.clitest
@@ -15,6 +15,7 @@ EOF
 RUN validate --default-dialect https://json-schema.org/draft/2020-12/schema schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2020_12_default_dialect_config.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config.clitest
@@ -25,6 +25,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2020_12_default_dialect_config_parent.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config_parent.clitest
@@ -27,6 +27,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/level1/level2/level3/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2020_12_default_dialect_config_relative.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config_relative.clitest
@@ -25,6 +25,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2020_12_fast.clitest
+++ b/test/validate/pass_2020_12_fast.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json --fast STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2020_12_fast_with_template.clitest
+++ b/test/validate/pass_2020_12_fast_with_template.clitest
@@ -22,6 +22,7 @@ EXTRACT STDOUT FROM result_0.txt INTO template.json
 RUN validate schema.json instance.json --fast --template template.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/validate/pass_2020_12_format_assertion.clitest
+++ b/test/validate/pass_2020_12_format_assertion.clitest
@@ -35,6 +35,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2020_12_format_assertion_optional.clitest
+++ b/test/validate/pass_2020_12_format_assertion_optional.clitest
@@ -35,6 +35,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2020_12_http.clitest
+++ b/test/validate/pass_2020_12_http.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_2020_12_with_template.clitest
+++ b/test/validate/pass_2020_12_with_template.clitest
@@ -22,6 +22,7 @@ EXTRACT STDOUT FROM result_0.txt INTO template.json
 RUN validate schema.json instance.json --template template.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 
 WRITE expected_1.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/validate/pass_boolean_schema_true_default_dialect.clitest
+++ b/test/validate/pass_boolean_schema_true_default_dialect.clitest
@@ -9,6 +9,7 @@ EOF
 RUN validate --default-dialect https://json-schema.org/draft/2020-12/schema schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_bundled_metaschema.clitest
+++ b/test/validate/pass_bundled_metaschema.clitest
@@ -24,6 +24,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_config_ignore.clitest
+++ b/test/validate/pass_config_ignore.clitest
@@ -35,6 +35,7 @@ EOF
 RUN validate schema.json instances STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_config_ignore_with_cli.clitest
+++ b/test/validate/pass_config_ignore_with_cli.clitest
@@ -50,6 +50,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Using extension: .yml
 2> ok: [CWD]/instances/valid.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_configuration_option.clitest
+++ b/test/validate/pass_configuration_option.clitest
@@ -28,6 +28,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_configuration_option_custom_name.clitest
+++ b/test/validate/pass_configuration_option_custom_name.clitest
@@ -26,6 +26,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/jsonschema.ci.json
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_configuration_option_directory.clitest
+++ b/test/validate/pass_configuration_option_directory.clitest
@@ -28,6 +28,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_configuration_option_over_discovered.clitest
+++ b/test/validate/pass_configuration_option_over_discovered.clitest
@@ -34,6 +34,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_configuration_option_short.clitest
+++ b/test/validate/pass_configuration_option_short.clitest
@@ -28,6 +28,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_custom_extension_json.clitest
+++ b/test/validate/pass_custom_extension_json.clitest
@@ -13,6 +13,7 @@ EOF
 RUN validate schema.custom instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_custom_extension_yaml.clitest
+++ b/test/validate/pass_custom_extension_yaml.clitest
@@ -11,6 +11,7 @@ EOF
 RUN validate schema.custom instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_cwd.clitest
+++ b/test/validate/pass_cwd.clitest
@@ -32,6 +32,8 @@ WRITE expected.txt UNTIL EOF
 2>   matches [CWD]/schema.json
 2> ok: [CWD]/schema.json
 2>   matches [CWD]/schema.json
+2>
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/validate/pass_cwd_config_no_path.clitest
+++ b/test/validate/pass_cwd_config_no_path.clitest
@@ -39,6 +39,8 @@ WRITE expected.txt UNTIL EOF
 2>   matches [CWD]/schema.json
 2> ok: [CWD]/schema.json
 2>   matches [CWD]/schema.json
+2>
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/validate/pass_default_dialect_cli_relative.clitest
+++ b/test/validate/pass_default_dialect_cli_relative.clitest
@@ -29,6 +29,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/sub/instance.json
 2>   matches [CWD]/sub/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_directory.clitest
+++ b/test/validate/pass_directory.clitest
@@ -28,6 +28,7 @@ EOF
 RUN validate schema.json instances STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_directory_and_file.clitest
+++ b/test/validate/pass_directory_and_file.clitest
@@ -29,6 +29,7 @@ EOF
 RUN validate schema.json single.json instances STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_directory_extension.clitest
+++ b/test/validate/pass_directory_extension.clitest
@@ -29,6 +29,7 @@ EOF
 RUN validate schema.json instances --extension .data.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_directory_extension_verbose.clitest
+++ b/test/validate/pass_directory_extension_verbose.clitest
@@ -35,6 +35,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   matches [CWD]/schema.json
 2> ok: [CWD]/instances/instance_2.data.json
 2>   matches [CWD]/schema.json
+2>
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_directory_fast.clitest
+++ b/test/validate/pass_directory_fast.clitest
@@ -28,6 +28,7 @@ EOF
 RUN validate schema.json instances --fast STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_directory_ignore.clitest
+++ b/test/validate/pass_directory_ignore.clitest
@@ -25,6 +25,7 @@ EOF
 RUN validate schema.json instances --ignore instances/drafts STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_directory_ignore_jsonl.clitest
+++ b/test/validate/pass_directory_ignore_jsonl.clitest
@@ -31,6 +31,7 @@ EOF
 RUN validate schema.json instances STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_directory_ignore_verbose.clitest
+++ b/test/validate/pass_directory_ignore_verbose.clitest
@@ -29,6 +29,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Ignoring path: "[CWD]/instances/drafts"
 2> ok: [CWD]/instances/instance_1.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_directory_multiple.clitest
+++ b/test/validate/pass_directory_multiple.clitest
@@ -35,6 +35,7 @@ EOF
 RUN validate schema.json dir1 dir2 STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 4 validated, 4 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_directory_verbose.clitest
+++ b/test/validate/pass_directory_verbose.clitest
@@ -33,6 +33,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   matches [CWD]/schema.json
 2> ok: [CWD]/instances/instance_2.json
 2>   matches [CWD]/schema.json
+2>
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_draft3.clitest
+++ b/test/validate/pass_draft3.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_draft3_https.clitest
+++ b/test/validate/pass_draft3_https.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_draft4.clitest
+++ b/test/validate/pass_draft4.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_draft4_https.clitest
+++ b/test/validate/pass_draft4_https.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_draft6.clitest
+++ b/test/validate/pass_draft6.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_draft6_https.clitest
+++ b/test/validate/pass_draft6_https.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_draft7.clitest
+++ b/test/validate/pass_draft7.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_draft7_https.clitest
+++ b/test/validate/pass_draft7_https.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_entrypoint_pointer.clitest
+++ b/test/validate/pass_entrypoint_pointer.clitest
@@ -22,6 +22,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_entrypoint_pointer_fragment.clitest
+++ b/test/validate/pass_entrypoint_pointer_fragment.clitest
@@ -22,6 +22,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_entrypoint_pointer_fragment_space.clitest
+++ b/test/validate/pass_entrypoint_pointer_fragment_space.clitest
@@ -22,6 +22,8 @@ REPLACE $CWD WITH '[CWD]' IN result.txt
 WRITE expected.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/validate/pass_entrypoint_pointer_space.clitest
+++ b/test/validate/pass_entrypoint_pointer_space.clitest
@@ -22,6 +22,8 @@ REPLACE $CWD WITH '[CWD]' IN result.txt
 WRITE expected.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/validate/pass_entrypoint_uri.clitest
+++ b/test/validate/pass_entrypoint_uri.clitest
@@ -23,6 +23,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_extension_empty_json.clitest
+++ b/test/validate/pass_extension_empty_json.clitest
@@ -34,6 +34,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   matches [CWD]/schema.json
 2> ok: [CWD]/instances/instance2
 2>   matches [CWD]/schema.json
+2>
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_extension_empty_yaml.clitest
+++ b/test/validate/pass_extension_empty_yaml.clitest
@@ -34,6 +34,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   matches [CWD]/schema.json
 2> ok: [CWD]/instances/instance2
 2>   matches [CWD]/schema.json
+2>
+2> 2 validated, 2 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_json_ref_yaml.clitest
+++ b/test/validate/pass_json_ref_yaml.clitest
@@ -20,6 +20,7 @@ EOF
 RUN validate schema.json --resolve schema.yaml instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_jsonl.clitest
+++ b/test/validate/pass_jsonl.clitest
@@ -20,6 +20,7 @@ EOF
 RUN validate schema.json instance.jsonl STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_jsonl_bigint.clitest
+++ b/test/validate/pass_jsonl_bigint.clitest
@@ -16,6 +16,7 @@ EOF
 RUN validate schema.json instance.jsonl STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_jsonl_gz.clitest
+++ b/test/validate/pass_jsonl_gz.clitest
@@ -24,6 +24,7 @@ RUN validate schema.json instance.jsonl.gz STDIN /dev/null IN . INTO result_0.tx
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_jsonl_gz_verbose.clitest
+++ b/test/validate/pass_jsonl_gz_verbose.clitest
@@ -31,6 +31,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   matches [CWD]/schema.json
 2> ok: [CWD]/instance.jsonl.gz (entry #3)
 2>   matches [CWD]/schema.json
+2>
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_jsonl_verbose.clitest
+++ b/test/validate/pass_jsonl_verbose.clitest
@@ -29,6 +29,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   matches [CWD]/schema.json
 2> ok: [CWD]/instance.jsonl (entry #3)
 2>   matches [CWD]/schema.json
+2>
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_many.clitest
+++ b/test/validate/pass_many.clitest
@@ -26,6 +26,7 @@ EOF
 RUN validate schema.json instance_1.json instance_2.json instance_3.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_many_one_empty_directory.clitest
+++ b/test/validate/pass_many_one_empty_directory.clitest
@@ -25,6 +25,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instances/instance_1.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_many_verbose.clitest
+++ b/test/validate/pass_many_verbose.clitest
@@ -34,6 +34,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   matches [CWD]/schema.json
 2> ok: [CWD]/instance_3.json
 2>   matches [CWD]/schema.json
+2>
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_no_identifier_half_ref.clitest
+++ b/test/validate/pass_no_identifier_half_ref.clitest
@@ -26,6 +26,7 @@ EOF
 RUN validate schema.json --resolve schemas instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_no_identifier_ref.clitest
+++ b/test/validate/pass_no_identifier_ref.clitest
@@ -25,6 +25,7 @@ EOF
 RUN validate schema.json --resolve schemas instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_no_identifier_ref_without_resolve.clitest
+++ b/test/validate/pass_no_identifier_ref_without_resolve.clitest
@@ -29,6 +29,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_resolve.clitest
+++ b/test/validate/pass_resolve.clitest
@@ -54,6 +54,7 @@ EOF
 RUN validate schema.json instance.json --resolve foo.json --resolve schemas STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_resolve_custom_extension.clitest
+++ b/test/validate/pass_resolve_custom_extension.clitest
@@ -50,6 +50,7 @@ EOF
 RUN validate schema.json instance.json --resolve foo.schema --resolve schemas --extension .schema STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_resolve_custom_metaschema_chain.clitest
+++ b/test/validate/pass_resolve_custom_metaschema_chain.clitest
@@ -70,6 +70,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_resolve_custom_metaschema_ordering.clitest
+++ b/test/validate/pass_resolve_custom_metaschema_ordering.clitest
@@ -43,6 +43,8 @@ WRITE expected_0.txt UNTIL EOF
 2> debug: Importing schema into the resolution context: https://example.com/my-schema
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_resolve_custom_metaschema_ordering_reversed.clitest
+++ b/test/validate/pass_resolve_custom_metaschema_ordering_reversed.clitest
@@ -61,6 +61,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_resolve_debug.clitest
+++ b/test/validate/pass_resolve_debug.clitest
@@ -68,6 +68,8 @@ WRITE expected_0.txt UNTIL EOF
 2> debug: Importing schema into the resolution context: https://example.com/bar
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_resolve_directory_metaschema_ordering.clitest
+++ b/test/validate/pass_resolve_directory_metaschema_ordering.clitest
@@ -73,6 +73,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt
@@ -84,6 +86,8 @@ REPLACE $CWD WITH '[CWD]' IN result_1.txt
 WRITE expected_1.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/validate/pass_resolve_duplicate_identifier_identical.clitest
+++ b/test/validate/pass_resolve_duplicate_identifier_identical.clitest
@@ -41,6 +41,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_resolve_remap.clitest
+++ b/test/validate/pass_resolve_remap.clitest
@@ -40,6 +40,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Using extension: .yml
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_resolve_remap_relative.clitest
+++ b/test/validate/pass_resolve_remap_relative.clitest
@@ -40,6 +40,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Using extension: .yml
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_resolve_verbose.clitest
+++ b/test/validate/pass_resolve_verbose.clitest
@@ -58,6 +58,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_resolve_without_identifier.clitest
+++ b/test/validate/pass_resolve_without_identifier.clitest
@@ -25,6 +25,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_stdin_instance.clitest
+++ b/test/validate/pass_stdin_instance.clitest
@@ -12,6 +12,7 @@ EOF
 RUN validate schema.json - STDIN stdin_input IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_stdin_instance_verbose.clitest
+++ b/test/validate/pass_stdin_instance_verbose.clitest
@@ -22,6 +22,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: tag:sourcemeta.com,2026:jsonschema/stdin
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_stdin_mixed_ordering.clitest
+++ b/test/validate/pass_stdin_mixed_ordering.clitest
@@ -28,6 +28,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   matches [CWD]/schema.json
 2> ok: [CWD]/instance2.json
 2>   matches [CWD]/schema.json
+2>
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_stdin_resolve.clitest
+++ b/test/validate/pass_stdin_resolve.clitest
@@ -22,6 +22,8 @@ REPLACE $CWD WITH '[CWD]' IN result.txt
 WRITE expected.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches tag:sourcemeta.com,2026:jsonschema/stdin
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/validate/pass_stdin_schema.clitest
+++ b/test/validate/pass_stdin_schema.clitest
@@ -15,6 +15,7 @@ EOF
 RUN validate - instance.json STDIN stdin_0 IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_stdin_schema_no_id.clitest
+++ b/test/validate/pass_stdin_schema_no_id.clitest
@@ -12,6 +12,7 @@ EOF
 RUN validate - instance.json STDIN stdin_0 IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_stdin_schema_verbose.clitest
+++ b/test/validate/pass_stdin_schema_verbose.clitest
@@ -19,6 +19,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches tag:sourcemeta.com,2026:jsonschema/stdin
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_stdin_yaml.clitest
+++ b/test/validate/pass_stdin_yaml.clitest
@@ -17,6 +17,7 @@ EOF
 RUN validate schema.json - STDIN stdin_input IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_verbose.clitest
+++ b/test/validate/pass_verbose.clitest
@@ -22,6 +22,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_verbose_with_template.clitest
+++ b/test/validate/pass_verbose_with_template.clitest
@@ -27,6 +27,8 @@ WRITE expected_1.txt UNTIL EOF
 2> Parsing pre-compiled schema template: [CWD]/template.json
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_1.txt AGAINST expected_1.txt

--- a/test/validate/pass_with_invalid_template.clitest
+++ b/test/validate/pass_with_invalid_template.clitest
@@ -23,6 +23,7 @@ RUN validate schema.json instance.json --template template.json STDIN /dev/null 
 
 WRITE expected_0.txt UNTIL EOF
 2> warning: Failed to parse pre-compiled schema template. Compiling from scratch
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_with_invalid_template_verbose.clitest
+++ b/test/validate/pass_with_invalid_template_verbose.clitest
@@ -28,6 +28,8 @@ WRITE expected_0.txt UNTIL EOF
 2> warning: Failed to parse pre-compiled schema template. Compiling from scratch
 2> ok: [CWD]/instance.json
 2>   matches [CWD]/schema.json
+2>
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_without_extension_json.clitest
+++ b/test/validate/pass_without_extension_json.clitest
@@ -18,6 +18,7 @@ EOF
 RUN validate schema instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_without_extension_yaml.clitest
+++ b/test/validate/pass_without_extension_yaml.clitest
@@ -14,6 +14,7 @@ EOF
 RUN validate schema instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 1 validated, 1 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_yaml_multi.clitest
+++ b/test/validate/pass_yaml_multi.clitest
@@ -23,6 +23,7 @@ EOF
 RUN validate schema.json instance.yaml STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 WRITE expected_0.txt UNTIL EOF
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_yaml_multi_verbose.clitest
+++ b/test/validate/pass_yaml_multi_verbose.clitest
@@ -32,6 +32,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   matches [CWD]/schema.json
 2> ok: [CWD]/instance.yaml (entry #3)
 2>   matches [CWD]/schema.json
+2>
+2> 3 validated, 3 passed, 0 failed
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

