### PR TITLE
Say when `validate` stopped early and point at `--continue/-c`

### DIFF
--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -512,6 +512,11 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
     print_summary(summary, options, std::cerr);
   }
 
+  if (summary.stopped) {
+    LOG_WARNING()
+        << "Stopped at first failure, pass --continue/-c to keep going\n";
+  }
+
   if (summary.failed > 0) {
     throw Fail{EXIT_EXPECTED_FAILURE};
   }

--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -12,6 +12,7 @@
 #include <chrono>      // std::chrono
 #include <cmath>       // std::sqrt
 #include <iostream>    // std::cerr
+#include <iterator>    // std::next
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -370,18 +371,21 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
                                 "given a single instance"};
     }
 
-    for (const auto &entry :
-         for_each_json({}, options, InputRequirement::NonEmpty)) {
-      if (!process_entry(entry, evaluator, schema_template, benchmark,
+    const auto entries{for_each_json({}, options, InputRequirement::NonEmpty)};
+    for (auto entry{entries.cbegin()}; entry != entries.cend(); ++entry) {
+      if (!process_entry(*entry, evaluator, schema_template, benchmark,
                          benchmark_loop, trace, fast_mode, json_output,
                          continue_on_error, schema_resolution_base, options,
                          summary)) {
+        summary.stopped = std::next(entry) != entries.cend();
         break;
       }
     }
   } else {
     bool proceed{true};
-    for (const auto &instance_path_view : instance_arguments) {
+    for (auto argument{instance_arguments.cbegin()};
+         argument != instance_arguments.cend(); ++argument) {
+      const auto &instance_path_view{*argument};
       const std::filesystem::path instance_path{instance_path_view};
       if (trace && (instance_path.extension() == ".jsonl" ||
                     instance_path.string().ends_with(".jsonl.gz"))) {
@@ -407,11 +411,13 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
           instance_path.string().ends_with(".jsonl.gz") ||
           instance_path.extension() == ".yaml" ||
           instance_path.extension() == ".yml") {
-        for (const auto &entry : for_each_json({instance_path_view}, options)) {
-          if (!process_entry(entry, evaluator, schema_template, benchmark,
+        const auto entries{for_each_json({instance_path_view}, options)};
+        for (auto entry{entries.cbegin()}; entry != entries.cend(); ++entry) {
+          if (!process_entry(*entry, evaluator, schema_template, benchmark,
                              benchmark_loop, trace, fast_mode, json_output,
                              continue_on_error, schema_resolution_base, options,
                              summary)) {
+            summary.stopped = std::next(entry) != entries.cend();
             proceed = false;
             break;
           }
@@ -488,6 +494,10 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
       }
 
       if (!proceed) {
+        if (std::next(argument) != instance_arguments.cend()) {
+          summary.stopped = true;
+        }
+
         break;
       }
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,6 +15,7 @@
 
 #include "error.h"
 #include "input.h"
+#include "logger.h"
 
 #include <algorithm>   // std::max, std::ranges::all_of
 #include <cctype>      // std::isdigit
@@ -449,6 +450,7 @@ inline auto print(const Entries &output,
 struct ValidationSummary {
   std::size_t validated{0};
   std::size_t failed{0};
+  bool stopped{false};
 };
 
 inline auto print_summary(const ValidationSummary &summary,
@@ -462,6 +464,11 @@ inline auto print_summary(const ValidationSummary &summary,
   stream << summary.validated << " validated, "
          << (summary.validated - summary.failed) << " passed, "
          << summary.failed << " failed\n";
+
+  if (summary.stopped) {
+    LOG_WARNING()
+        << "Stopped at first failure, pass --continue/-c to keep going\n";
+  }
 }
 
 inline auto

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,7 +15,6 @@
 
 #include "error.h"
 #include "input.h"
-#include "logger.h"
 
 #include <algorithm>   // std::max, std::ranges::all_of
 #include <cctype>      // std::isdigit
@@ -464,11 +463,6 @@ inline auto print_summary(const ValidationSummary &summary,
   stream << summary.validated << " validated, "
          << (summary.validated - summary.failed) << " passed, "
          << summary.failed << " failed\n";
-
-  if (summary.stopped) {
-    LOG_WARNING()
-        << "Stopped at first failure, pass --continue/-c to keep going\n";
-  }
 }
 
 inline auto

--- a/test/validate/fail_benchmark_jsonl.clitest
+++ b/test/validate/fail_benchmark_jsonl.clitest
@@ -22,6 +22,7 @@ REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH 
 WRITE expected_0.txt UNTIL EOF
 1> [CWD]/instance.jsonl[1]: PASS [TIMING]
 1> [CWD]/instance.jsonl[2]: FAIL [TIMING]
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_directory_stop_json.clitest
+++ b/test/validate/fail_directory_stop_json.clitest
@@ -52,6 +52,7 @@ WRITE expected_0.txt UNTIL EOF
 1>   ]
 1> }
 2> [CWD]/instances/instance_1.json
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_directory_stop_verbose.clitest
+++ b/test/validate/fail_directory_stop_verbose.clitest
@@ -38,6 +38,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/properties"
 2>
 2> 1 validated, 0 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_all.clitest
+++ b/test/validate/fail_jsonl_all.clitest
@@ -31,6 +31,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/type"
 2>
 2> 1 validated, 0 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_all_verbose.clitest
+++ b/test/validate/fail_jsonl_all_verbose.clitest
@@ -32,6 +32,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/type"
 2>
 2> 1 validated, 0 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_gz_one.clitest
+++ b/test/validate/fail_jsonl_gz_one.clitest
@@ -35,6 +35,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/type"
 2>
 2> 2 validated, 1 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_gz_one_json.clitest
+++ b/test/validate/fail_jsonl_gz_one_json.clitest
@@ -36,6 +36,7 @@ WRITE expected_0.txt UNTIL EOF
 1>     }
 1>   ]
 1> }
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_gz_one_json_verbose.clitest
+++ b/test/validate/fail_jsonl_gz_one_json_verbose.clitest
@@ -37,6 +37,7 @@ WRITE expected_0.txt UNTIL EOF
 1>   ]
 1> }
 2> Interpreting input as GZIP-compressed JSONL: [CWD]/instance.jsonl.gz
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_gz_one_verbose.clitest
+++ b/test/validate/fail_jsonl_gz_one_verbose.clitest
@@ -38,6 +38,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/type"
 2>
 2> 2 validated, 1 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_one.clitest
+++ b/test/validate/fail_jsonl_one.clitest
@@ -33,6 +33,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/type"
 2>
 2> 2 validated, 1 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_one_json.clitest
+++ b/test/validate/fail_jsonl_one_json.clitest
@@ -34,6 +34,7 @@ WRITE expected_0.txt UNTIL EOF
 1>     }
 1>   ]
 1> }
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_one_json_verbose.clitest
+++ b/test/validate/fail_jsonl_one_json_verbose.clitest
@@ -35,6 +35,7 @@ WRITE expected_0.txt UNTIL EOF
 1>   ]
 1> }
 2> Interpreting input as JSONL: [CWD]/instance.jsonl
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_jsonl_one_verbose.clitest
+++ b/test/validate/fail_jsonl_one_verbose.clitest
@@ -36,6 +36,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/type"
 2>
 2> 2 validated, 1 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_many.clitest
+++ b/test/validate/fail_many.clitest
@@ -40,6 +40,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/properties"
 2>
 2> 2 validated, 1 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_many_verbose.clitest
+++ b/test/validate/fail_many_verbose.clitest
@@ -42,6 +42,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/properties"
 2>
 2> 2 validated, 1 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_yaml_multi_blank_lines.clitest
+++ b/test/validate/fail_yaml_multi_blank_lines.clitest
@@ -41,6 +41,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/type"
 2>
 2> 2 validated, 1 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_yaml_multi_one.clitest
+++ b/test/validate/fail_yaml_multi_one.clitest
@@ -36,6 +36,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/type"
 2>
 2> 2 validated, 1 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_yaml_multi_one_json.clitest
+++ b/test/validate/fail_yaml_multi_one_json.clitest
@@ -38,6 +38,7 @@ WRITE expected_0.txt UNTIL EOF
 1>     }
 1>   ]
 1> }
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_yaml_multi_one_verbose.clitest
+++ b/test/validate/fail_yaml_multi_one_verbose.clitest
@@ -39,6 +39,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/type"
 2>
 2> 2 validated, 1 passed, 1 failed
+2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

