### PR TITLE
Remove outdated `Releasing` docs (we have `release.sh` now)

### DIFF
--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -21,24 +21,3 @@ nmake
 The default target will build the project and run the test suite. You will also
 find the CLI binary under `build/`. The specific location varies depending on
 your CMake default generator.
-
-Releasing
----------
-
-```sh
-git checkout main
-
-# Update the VERSION in CMakeLists.txt
-vim CMakeLists.txt
-# Update the version in action.yml
-vim action.yml
-# Update the version in the GitHub Actions example
-vim README.markdown
-
-git add CMakeLists.txt action.yml
-git commit -m "vX.Y.Z"
-git tag -a "vX.Y.Z" -m "vX.Y.Z"
-git push
-```
-
-Then update https://github.com/sourcemeta/homebrew-apps.


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

