### PR TITLE
Print `validate` and `metaschema` paths relative to the working directory

### DIFF
--- a/src/command_metaschema.cc
+++ b/src/command_metaschema.cc
@@ -119,7 +119,7 @@ auto sourcemeta::jsonschema::metaschema(
       } else if (json_output) {
         // Otherwise its impossible to correlate the output
         // when validating i.e. a directory of schemas
-        std::cerr << entry.first << "\n";
+        std::cerr << relative_path_string(entry.resolution_base) << "\n";
         const auto output{sourcemeta::blaze::standard(
             evaluator, cache.at(std::string{dialect}), entry.second,
             sourcemeta::blaze::StandardOutput::Basic, entry.positions)};
@@ -137,9 +137,11 @@ auto sourcemeta::jsonschema::metaschema(
         if (evaluator.validate(cache.at(std::string{dialect}), entry.second,
                                std::ref(output))) {
           LOG_VERBOSE(options)
-              << "ok: " << entry.first << "\n  matches " << dialect << "\n";
+              << "ok: " << relative_path_string(entry.resolution_base)
+              << "\n  matches " << dialect << "\n";
         } else {
-          std::cerr << "fail: " << entry.first << "\n";
+          std::cerr << "fail: " << relative_path_string(entry.resolution_base)
+                    << "\n";
           print(output, entry.positions, std::cerr);
           summary.failed += 1;
         }

--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -144,7 +144,7 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
                    const sourcemeta::blaze::Template &schema_template,
                    bool benchmark, std::uint64_t benchmark_loop, bool trace,
                    bool fast_mode, bool json_output, bool continue_on_error,
-                   const std::filesystem::path &schema_resolution_base,
+                   const std::filesystem::path &schema_display_path,
                    const sourcemeta::core::Options &options,
                    sourcemeta::jsonschema::ValidationSummary &summary) -> bool {
   sourcemeta::blaze::SimpleOutput output{entry.second};
@@ -216,7 +216,7 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
     }
     sourcemeta::jsonschema::LOG_VERBOSE(options)
         << "\n  matches "
-        << sourcemeta::jsonschema::relative_path_string(schema_resolution_base)
+        << sourcemeta::jsonschema::relative_path_string(schema_display_path)
         << "\n";
   } else {
     if (continue_on_error && entry.multidocument && summary.failed > 0) {
@@ -270,6 +270,10 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
                                     : std::filesystem::path(schema_path)};
   const auto schema_resolution_base{
       schema_from_stdin ? stdin_path() : std::filesystem::path(schema_path)};
+  const auto schema_display_path{
+      schema_from_stdin
+          ? stdin_path()
+          : sourcemeta::core::weakly_canonical(schema_resolution_base)};
 
   const auto configuration_path{
       find_configuration(options, schema_config_base)};
@@ -382,7 +386,7 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
     for (auto entry{entries.cbegin()}; entry != entries.cend(); ++entry) {
       if (!process_entry(*entry, evaluator, schema_template, benchmark,
                          benchmark_loop, trace, fast_mode, json_output,
-                         continue_on_error, schema_resolution_base, options,
+                         continue_on_error, schema_display_path, options,
                          summary)) {
         summary.stopped = std::next(entry) != entries.cend();
         break;
@@ -422,7 +426,7 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
         for (auto entry{entries.cbegin()}; entry != entries.cend(); ++entry) {
           if (!process_entry(*entry, evaluator, schema_template, benchmark,
                              benchmark_loop, trace, fast_mode, json_output,
-                             continue_on_error, schema_resolution_base, options,
+                             continue_on_error, schema_display_path, options,
                              summary)) {
             summary.stopped = std::next(entry) != entries.cend();
             proceed = false;
@@ -430,6 +434,8 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
           }
         }
       } else {
+        const auto instance_display_path{
+            sourcemeta::core::weakly_canonical(instance_path)};
         sourcemeta::core::PointerPositionTracker tracker;
         auto property_storage = std::make_shared<std::deque<std::string>>();
         const bool track_positions{(!fast_mode && !benchmark) || trace};
@@ -450,7 +456,7 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
         bool subresult{true};
         if (benchmark) {
           subresult = run_loop(evaluator, schema_template, instance,
-                               relative_path_string(instance_path),
+                               relative_path_string(instance_display_path),
                                static_cast<std::int64_t>(-1), benchmark_loop);
         } else if (trace) {
           subresult = evaluator.validate(schema_template, instance,
@@ -484,10 +490,12 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
           std::cout << "\n";
         } else if (subresult) {
           LOG_VERBOSE(options)
-              << "ok: " << relative_path_string(instance_path) << "\n  matches "
-              << relative_path_string(schema_resolution_base) << "\n";
+              << "ok: " << relative_path_string(instance_display_path)
+              << "\n  matches " << relative_path_string(schema_display_path)
+              << "\n";
         } else {
-          std::cerr << "fail: " << relative_path_string(instance_path) << "\n";
+          std::cerr << "fail: " << relative_path_string(instance_display_path)
+                    << "\n";
           print(output, tracker, std::cerr);
           summary.failed += 1;
           proceed = continue_on_error;

--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -154,11 +154,12 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
   bool subresult{true};
   summary.validated += 1;
   if (benchmark) {
-    subresult = run_loop(evaluator, schema_template, entry.second, entry.first,
-                         entry.multidocument
-                             ? static_cast<std::int64_t>(entry.index + 1)
-                             : static_cast<std::int64_t>(-1),
-                         benchmark_loop);
+    subresult = run_loop(
+        evaluator, schema_template, entry.second,
+        sourcemeta::jsonschema::relative_path_string(entry.resolution_base),
+        entry.multidocument ? static_cast<std::int64_t>(entry.index + 1)
+                            : static_cast<std::int64_t>(-1),
+        benchmark_loop);
     if (!subresult) {
       summary.failed += 1;
     }
@@ -182,7 +183,9 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
     }
   } else if (json_output) {
     if (!entry.multidocument) {
-      std::cerr << entry.first << "\n";
+      std::cerr << sourcemeta::jsonschema::relative_path_string(
+                       entry.resolution_base)
+                << "\n";
     }
     const auto suboutput{sourcemeta::blaze::standard(
         evaluator, schema_template, entry.second,
@@ -204,20 +207,24 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
     if (continue_on_error && entry.multidocument && summary.failed > 0) {
       sourcemeta::jsonschema::LOG_VERBOSE(options) << "\n";
     }
-    sourcemeta::jsonschema::LOG_VERBOSE(options) << "ok: " << entry.first;
+    sourcemeta::jsonschema::LOG_VERBOSE(options)
+        << "ok: "
+        << sourcemeta::jsonschema::relative_path_string(entry.resolution_base);
     if (entry.multidocument) {
       sourcemeta::jsonschema::LOG_VERBOSE(options)
           << " (entry #" << entry.index + 1 << ")";
     }
     sourcemeta::jsonschema::LOG_VERBOSE(options)
         << "\n  matches "
-        << sourcemeta::jsonschema::stdin_path_string(schema_resolution_base)
+        << sourcemeta::jsonschema::relative_path_string(schema_resolution_base)
         << "\n";
   } else {
     if (continue_on_error && entry.multidocument && summary.failed > 0) {
       std::cerr << "\n";
     }
-    std::cerr << "fail: " << entry.first;
+    std::cerr << "fail: "
+              << sourcemeta::jsonschema::relative_path_string(
+                     entry.resolution_base);
     if (entry.multidocument) {
       std::cerr << " (entry #" << entry.index + 1 << ")\n\n";
       sourcemeta::core::prettify(entry.second, std::cerr);
@@ -443,7 +450,7 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
         bool subresult{true};
         if (benchmark) {
           subresult = run_loop(evaluator, schema_template, instance,
-                               instance_path.generic_string(),
+                               relative_path_string(instance_path),
                                static_cast<std::int64_t>(-1), benchmark_loop);
         } else if (trace) {
           subresult = evaluator.validate(schema_template, instance,
@@ -477,16 +484,10 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
           std::cout << "\n";
         } else if (subresult) {
           LOG_VERBOSE(options)
-              << "ok: "
-              << sourcemeta::core::weakly_canonical(instance_path)
-                     .generic_string()
-              << "\n  matches " << stdin_path_string(schema_resolution_base)
-              << "\n";
+              << "ok: " << relative_path_string(instance_path) << "\n  matches "
+              << relative_path_string(schema_resolution_base) << "\n";
         } else {
-          std::cerr << "fail: "
-                    << sourcemeta::core::weakly_canonical(instance_path)
-                           .generic_string()
-                    << "\n";
+          std::cerr << "fail: " << relative_path_string(instance_path) << "\n";
           print(output, tracker, std::cerr);
           summary.failed += 1;
           proceed = continue_on_error;

--- a/src/error.h
+++ b/src/error.h
@@ -544,10 +544,13 @@ inline auto stdin_path_string(const std::filesystem::path &path)
   return sourcemeta::core::weakly_canonical(path).generic_string();
 }
 
-// Per instance output names paths the way the user did, while error output
-// keeps canonicalising through `stdin_path_string`. The input must already be
-// canonical, so that this stays a lexical comparison that we can afford to do
-// once per instance
+// Per instance output names paths relative to the working directory, while
+// error output stays absolute through `stdin_path_string`. Both the input and
+// the base are canonical, so a path reached through a symlink displays its
+// target rather than the argument. That is what keeps a symlinked working
+// directory resolving correctly, as `current_path()` is already resolved.
+// Requiring a canonical input also keeps this a lexical comparison that we can
+// afford once per instance
 inline auto relative_path_string(const std::filesystem::path &canonical)
     -> std::string {
   if (canonical == stdin_path()) {
@@ -555,9 +558,9 @@ inline auto relative_path_string(const std::filesystem::path &canonical)
   }
 
   // The working directory cannot change while a command runs
-  static const auto base{
+  static const auto WORKING_DIRECTORY{
       sourcemeta::core::weakly_canonical(std::filesystem::current_path())};
-  const auto result{canonical.lexically_relative(base)};
+  const auto result{canonical.lexically_relative(WORKING_DIRECTORY)};
   if (result.empty()) {
     return canonical.generic_string();
   }

--- a/src/error.h
+++ b/src/error.h
@@ -545,18 +545,17 @@ inline auto stdin_path_string(const std::filesystem::path &path)
 }
 
 // Per instance output names paths the way the user did, while error output
-// keeps canonicalising through `stdin_path_string`
-inline auto relative_path_string(const std::filesystem::path &path)
+// keeps canonicalising through `stdin_path_string`. The input must already be
+// canonical, so that this stays a lexical comparison that we can afford to do
+// once per instance
+inline auto relative_path_string(const std::filesystem::path &canonical)
     -> std::string {
-  if (path == stdin_path()) {
+  if (canonical == stdin_path()) {
     return std::string{STDIN_DEFAULT_ID};
   }
 
-  // Going through `sourcemeta::core::weakly_canonical` rather than
-  // `std::filesystem::relative` keeps the FIFO and FUSE guards that the
-  // standard one lacks, leaving only a lexical comparison to do
-  const auto canonical{sourcemeta::core::weakly_canonical(path)};
-  const auto base{
+  // The working directory cannot change while a command runs
+  static const auto base{
       sourcemeta::core::weakly_canonical(std::filesystem::current_path())};
   const auto result{canonical.lexically_relative(base)};
   if (result.empty()) {

--- a/src/error.h
+++ b/src/error.h
@@ -544,6 +544,28 @@ inline auto stdin_path_string(const std::filesystem::path &path)
   return sourcemeta::core::weakly_canonical(path).generic_string();
 }
 
+// Per instance output names paths the way the user did, while error output
+// keeps canonicalising through `stdin_path_string`
+inline auto relative_path_string(const std::filesystem::path &path)
+    -> std::string {
+  if (path == stdin_path()) {
+    return std::string{STDIN_DEFAULT_ID};
+  }
+
+  // Going through `sourcemeta::core::weakly_canonical` rather than
+  // `std::filesystem::relative` keeps the FIFO and FUSE guards that the
+  // standard one lacks, leaving only a lexical comparison to do
+  const auto canonical{sourcemeta::core::weakly_canonical(path)};
+  const auto base{
+      sourcemeta::core::weakly_canonical(std::filesystem::current_path())};
+  const auto result{canonical.lexically_relative(base)};
+  if (result.empty()) {
+    return canonical.generic_string();
+  }
+
+  return result.generic_string();
+}
+
 template <typename Exception>
 inline auto print_exception(const bool is_json, const Exception &exception)
     -> void {

--- a/test/bundle/pass_ref_in_bundled_resolves_against_id.clitest
+++ b/test/bundle/pass_ref_in_bundled_resolves_against_id.clitest
@@ -26,8 +26,6 @@ RUN bundle entry.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> {
 1>   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/bundle/pass_resolve_directory_verbose.clitest
+++ b/test/bundle/pass_resolve_directory_verbose.clitest
@@ -20,8 +20,6 @@ EOF
 
 RUN bundle schema.json --resolve schemas --verbose STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> {
 1>   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/bundle/pass_resolve_no_identifier.clitest
+++ b/test/bundle/pass_resolve_no_identifier.clitest
@@ -22,8 +22,6 @@ RUN bundle schema.json --resolve nested.json STDIN /dev/null IN . INTO result.tx
 EXTRACT STDOUT FROM result.txt INTO bundled.json
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/bundle/pass_without_id_verbose.clitest
+++ b/test/bundle/pass_without_id_verbose.clitest
@@ -20,8 +20,6 @@ EOF
 
 RUN bundle schema.json --resolve schemas --without-id --verbose STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> {
 1>   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/ci/pass_bundle_http.clitest
+++ b/test/ci/pass_bundle_http.clitest
@@ -12,8 +12,6 @@ EOF
 RUN bundle schema.json --http STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/test/ci/pass_install_add_http.clitest
+++ b/test/ci/pass_install_add_http.clitest
@@ -40,8 +40,6 @@ COMPARE project/vendor/identifier.json AGAINST expected_schema.json
 CHECKSUM SHA256 project/vendor/identifier.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/ci/pass_install_http.clitest
+++ b/test/ci/pass_install_http.clitest
@@ -211,8 +211,6 @@ COMPARE project/vendor/response.json AGAINST expected_schema.json
 CHECKSUM SHA256 project/vendor/response.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/ci/pass_validate_fuse.sh
+++ b/test/ci/pass_validate_fuse.sh
@@ -35,12 +35,12 @@ EOF
 
 bindfs --no-allow-other "$TMP" "$FUSE_MOUNT"
 
-"$1" validate --verbose "$FUSE_MOUNT/level1/level2/level3/schema.json" \
-  "$FUSE_MOUNT/instance.json" > "$TMP/output.txt" 2>&1
+( cd "$FUSE_MOUNT" && "$1" validate --verbose \
+  level1/level2/level3/schema.json instance.json ) > "$TMP/output.txt" 2>&1
 
-cat << EOF > "$TMP/expected.txt"
-ok: $(realpath "$FUSE_MOUNT")/instance.json
-  matches $(realpath "$FUSE_MOUNT")/level1/level2/level3/schema.json
+cat << 'EOF' > "$TMP/expected.txt"
+ok: instance.json
+  matches level1/level2/level3/schema.json
 
 1 validated, 1 passed, 0 failed
 EOF

--- a/test/compile/pass_format_assertion.clitest
+++ b/test/compile/pass_format_assertion.clitest
@@ -22,8 +22,6 @@ EOF
 RUN compile schema.json --resolve metaschema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> [
 1>   7,

--- a/test/compile/pass_format_assertion_flag.clitest
+++ b/test/compile/pass_format_assertion_flag.clitest
@@ -9,8 +9,6 @@ EOF
 RUN compile schema.json --format-assertion STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> [
 1>   7,

--- a/test/compile/pass_no_identifier.clitest
+++ b/test/compile/pass_no_identifier.clitest
@@ -12,8 +12,6 @@ EOF
 RUN compile foo/bar/baz/qux/very/long/path/foo/bar/baz/qux/schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> [
 1>   7,

--- a/test/compile/pass_patternproperties.clitest
+++ b/test/compile/pass_patternproperties.clitest
@@ -37,8 +37,6 @@ COMPARE validated.txt AGAINST expected.txt
 // Validation failure
 RUN validate --template template.json schema.json instance_invalid.json STDIN /dev/null IN . INTO validated_invalid.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN validated_invalid.txt
-
 WRITE expected_invalid.txt UNTIL EOF
 2> fail: instance_invalid.json
 2> error: Schema validation failure
@@ -58,8 +56,6 @@ COMPARE validated_invalid.txt AGAINST expected_invalid.txt
 RUN validate --template template.json schema.json instance_invalid.json --json STDIN /dev/null IN . INTO validated_invalid_json.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN validated_invalid_json.txt
-REPLACE $CWD WITH '[CWD]' IN validated_invalid_json.txt
-
 WRITE expected_invalid_json.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/compile/pass_patternproperties.clitest
+++ b/test/compile/pass_patternproperties.clitest
@@ -40,7 +40,7 @@ RUN validate --template template.json schema.json instance_invalid.json STDIN /d
 REPLACE $CWD WITH '[CWD]' IN validated_invalid.txt
 
 WRITE expected_invalid.txt UNTIL EOF
-2> fail: [CWD]/instance_invalid.json
+2> fail: instance_invalid.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo-bar" (line 1, column 3)

--- a/test/format/pass_bignum_real.clitest
+++ b/test/format/pass_bignum_real.clitest
@@ -9,8 +9,6 @@ EOF
 
 RUN fmt schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_check_single.clitest
+++ b/test/format/pass_check_single.clitest
@@ -9,8 +9,6 @@ EOF
 
 RUN fmt schema.json --check STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_check_single_indentation.clitest
+++ b/test/format/pass_check_single_indentation.clitest
@@ -9,8 +9,6 @@ EOF
 
 RUN fmt schema.json --check --indentation 4 STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_check_single_keep_ordering.clitest
+++ b/test/format/pass_check_single_keep_ordering.clitest
@@ -9,8 +9,6 @@ EOF
 
 RUN fmt schema.json --check --keep-ordering STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_config_ignore.clitest
+++ b/test/format/pass_config_ignore.clitest
@@ -22,8 +22,6 @@ EOF
 
 RUN fmt STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_default_dialect.clitest
+++ b/test/format/pass_default_dialect.clitest
@@ -8,8 +8,6 @@ EOF
 
 RUN fmt schema.json --default-dialect https://json-schema.org/draft/2020-12/schema STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_directory.clitest
+++ b/test/format/pass_directory.clitest
@@ -14,8 +14,6 @@ EOF
 
 RUN fmt . STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_directory_ignore_directory.clitest
+++ b/test/format/pass_directory_ignore_directory.clitest
@@ -14,8 +14,6 @@ EOF
 
 RUN fmt . --ignore nested STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_directory_ignore_file.clitest
+++ b/test/format/pass_directory_ignore_file.clitest
@@ -14,8 +14,6 @@ EOF
 
 RUN fmt . --ignore schema_2.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_single.clitest
+++ b/test/format/pass_single.clitest
@@ -10,8 +10,6 @@ EOF
 
 RUN fmt schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_single_2020_12_http.clitest
+++ b/test/format/pass_single_2020_12_http.clitest
@@ -10,8 +10,6 @@ EOF
 
 RUN fmt schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_single_draft3_https.clitest
+++ b/test/format/pass_single_draft3_https.clitest
@@ -10,8 +10,6 @@ EOF
 
 RUN fmt schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_single_draft7_https.clitest
+++ b/test/format/pass_single_draft7_https.clitest
@@ -10,8 +10,6 @@ EOF
 
 RUN fmt schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_single_indentation.clitest
+++ b/test/format/pass_single_indentation.clitest
@@ -10,8 +10,6 @@ EOF
 
 RUN fmt schema.json --indentation 4 STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_single_keep_ordering.clitest
+++ b/test/format/pass_single_keep_ordering.clitest
@@ -8,8 +8,6 @@ EOF
 
 RUN fmt --keep-ordering schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_test_document_explicit_dialect.clitest
+++ b/test/format/pass_test_document_explicit_dialect.clitest
@@ -7,8 +7,6 @@ EOF
 
 RUN fmt test.json --default-dialect https://json-schema.org/draft/2020-12/schema STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_test_document_schema_keyword.clitest
+++ b/test/format/pass_test_document_schema_keyword.clitest
@@ -14,8 +14,6 @@ EOF
 
 RUN fmt schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/format/pass_without_extension_json.clitest
+++ b/test/format/pass_without_extension_json.clitest
@@ -10,8 +10,6 @@ EOF
 
 RUN fmt schema STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 EOF
 

--- a/test/inspect/pass_boolean_schema_default_dialect.clitest
+++ b/test/inspect/pass_boolean_schema_default_dialect.clitest
@@ -5,8 +5,6 @@ EOF
 RUN inspect schema.json --default-dialect https://json-schema.org/draft/2020-12/schema STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> (RESOURCE) URI: [CWD_URI]/schema.json
 1>     Type              : Static

--- a/test/inspect/pass_default_dialect_cli_extension_fallback.clitest
+++ b/test/inspect/pass_default_dialect_cli_extension_fallback.clitest
@@ -17,8 +17,6 @@ EOF
 RUN inspect schema.json --default-dialect ./meta/custom STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> (RESOURCE) URI: https://example.com/x
 1>     Type              : Static

--- a/test/inspect/pass_default_dialect_config_extension_custom.clitest
+++ b/test/inspect/pass_default_dialect_config_extension_custom.clitest
@@ -24,8 +24,6 @@ EOF
 RUN inspect schema.dialect STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> (RESOURCE) URI: https://example.com/x
 1>     Type              : Static

--- a/test/inspect/pass_default_dialect_config_extension_fallback_json.clitest
+++ b/test/inspect/pass_default_dialect_config_extension_fallback_json.clitest
@@ -23,8 +23,6 @@ EOF
 RUN inspect schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> (RESOURCE) URI: https://example.com/x
 1>     Type              : Static

--- a/test/inspect/pass_default_dialect_config_extension_fallback_over_directory.clitest
+++ b/test/inspect/pass_default_dialect_config_extension_fallback_over_directory.clitest
@@ -27,8 +27,6 @@ EOF
 RUN inspect schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> (RESOURCE) URI: https://example.com/x
 1>     Type              : Static

--- a/test/inspect/pass_default_dialect_config_extension_fallback_yaml.clitest
+++ b/test/inspect/pass_default_dialect_config_extension_fallback_yaml.clitest
@@ -20,8 +20,6 @@ EOF
 RUN inspect schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> (RESOURCE) URI: https://example.com/x
 1>     Type              : Static

--- a/test/inspect/pass_default_dialect_config_path_no_base_shift.clitest
+++ b/test/inspect/pass_default_dialect_config_path_no_base_shift.clitest
@@ -24,8 +24,6 @@ EOF
 RUN inspect schemas/schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> (RESOURCE) URI: https://example.com/x
 1>     Type              : Static

--- a/test/inspect/pass_default_dialect_config_relative_uri.clitest
+++ b/test/inspect/pass_default_dialect_config_relative_uri.clitest
@@ -25,8 +25,6 @@ EOF
 RUN inspect schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> (RESOURCE) URI: https://example.com/x
 1>     Type              : Static

--- a/test/inspect/pass_no_identifier.clitest
+++ b/test/inspect/pass_no_identifier.clitest
@@ -13,8 +13,6 @@ EOF
 RUN inspect schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> (RESOURCE) URI: [CWD_URI]/schema.json
 1>     Type              : Static

--- a/test/inspect/pass_stdin_no_id.clitest
+++ b/test/inspect/pass_stdin_no_id.clitest
@@ -7,8 +7,6 @@ EOF
 
 RUN inspect - STDIN input.json IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> (RESOURCE) URI: tag:sourcemeta.com,2026:jsonschema/stdin
 1>     Type              : Static

--- a/test/install/fail_creates_parent_over_file.clitest
+++ b/test/install/fail_creates_parent_over_file.clitest
@@ -26,8 +26,6 @@ REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 RUN install STDIN /dev/null IN project INTO result_0.txt EXPECTING 6
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> Fetching       : [CWD_URI]/source/user.json
 2> error: Failed to write schema
@@ -40,8 +38,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN install --json STDIN /dev/null IN project INTO result_1.txt EXPECTING 6
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 1> {
 1>   "events": [

--- a/test/install/fail_frozen_multiple_errors.clitest
+++ b/test/install/fail_frozen_multiple_errors.clitest
@@ -45,8 +45,6 @@ COPY project/jsonschema.lock.json TO lock_before.json
 RUN install --frozen STDIN /dev/null IN project INTO result_1.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 2> Untracked      : file:///tmp/fake/new.json
 2> Orphaned       : [CWD_URI]/source/schema.json
@@ -58,8 +56,6 @@ COMPARE result_1.txt AGAINST expected_1.txt
 RUN install --frozen --json STDIN /dev/null IN project INTO result_2.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_2.txt
-REPLACE $CWD WITH '[CWD]' IN result_2.txt
-
 WRITE expected_2.txt UNTIL EOF
 1> {
 1>   "events": [

--- a/test/install/fail_frozen_orphaned.clitest
+++ b/test/install/fail_frozen_orphaned.clitest
@@ -57,8 +57,6 @@ COPY project/jsonschema.lock.json TO lock_before.json
 RUN install --frozen STDIN /dev/null IN project INTO result_1.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 2> Up to date     : [CWD_URI]/source/schema.json
 2> Orphaned       : [CWD_URI]/source/other.json
@@ -70,8 +68,6 @@ COMPARE result_1.txt AGAINST expected_1.txt
 RUN install --frozen --json STDIN /dev/null IN project INTO result_2.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_2.txt
-REPLACE $CWD WITH '[CWD]' IN result_2.txt
-
 WRITE expected_2.txt UNTIL EOF
 1> {
 1>   "events": [

--- a/test/install/fail_frozen_path_mismatch.clitest
+++ b/test/install/fail_frozen_path_mismatch.clitest
@@ -41,8 +41,6 @@ COPY project/jsonschema.lock.json TO lock_before.json
 RUN install --frozen STDIN /dev/null IN project INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> Path mismatch  : [CWD_URI]/source/schema.json
 2> error: Configured path does not match lock file in frozen mode
@@ -55,8 +53,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN install --frozen --json STDIN /dev/null IN project INTO result_1.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 1> {
 1>   "events": [

--- a/test/install/fail_frozen_untracked.clitest
+++ b/test/install/fail_frozen_untracked.clitest
@@ -48,8 +48,6 @@ COPY project/jsonschema.lock.json TO lock_before.json
 RUN install --frozen STDIN /dev/null IN project INTO result_1.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 2> Up to date     : [CWD_URI]/source/schema.json
 2> Untracked      : file:///zzz/fake/new.json
@@ -61,8 +59,6 @@ COMPARE result_1.txt AGAINST expected_1.txt
 RUN install --frozen --json STDIN /dev/null IN project INTO result_2.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_2.txt
-REPLACE $CWD WITH '[CWD]' IN result_2.txt
-
 WRITE expected_2.txt UNTIL EOF
 1> {
 1>   "events": [

--- a/test/install/pass_add_dependency.clitest
+++ b/test/install/pass_add_dependency.clitest
@@ -30,8 +30,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/jsonschema.json TO checked_config.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_config.json
-REPLACE $CWD WITH '[CWD]' IN checked_config.json
-
 WRITE expected_config.json UNTIL EOF
 {
   "dependencies": {
@@ -44,8 +42,6 @@ COMPARE checked_config.json AGAINST expected_config.json
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -60,8 +56,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_add_dependency_absolute_path.clitest
+++ b/test/install/pass_add_dependency_absolute_path.clitest
@@ -30,8 +30,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/jsonschema.json TO checked_file_1.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_file_1.txt
-REPLACE $CWD WITH '[CWD]' IN checked_file_1.txt
-
 WRITE expected_file_1.txt UNTIL EOF
 {
   "dependencies": {

--- a/test/install/pass_add_dependency_config_path.clitest
+++ b/test/install/pass_add_dependency_config_path.clitest
@@ -30,8 +30,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/jsonschema.json TO checked_config.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_config.json
-REPLACE $CWD WITH '[CWD]' IN checked_config.json
-
 WRITE expected_config.json UNTIL EOF
 {
   "path": "./schemas",

--- a/test/install/pass_add_dependency_dot_dot_path.clitest
+++ b/test/install/pass_add_dependency_dot_dot_path.clitest
@@ -30,8 +30,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/jsonschema.json TO checked_file_1.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_file_1.txt
-REPLACE $CWD WITH '[CWD]' IN checked_file_1.txt
-
 WRITE expected_file_1.txt UNTIL EOF
 {
   "dependencies": {
@@ -44,8 +42,6 @@ COMPARE checked_file_1.txt AGAINST expected_file_1.txt
 
 COPY vendor/user.json TO checked_file_2.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_file_2.txt
-REPLACE $CWD WITH '[CWD]' IN checked_file_2.txt
-
 WRITE expected_file_2.txt UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/install/pass_add_dependency_existing_deps.clitest
+++ b/test/install/pass_add_dependency_existing_deps.clitest
@@ -54,8 +54,6 @@ COMPARE result_1.txt AGAINST expected_1.txt
 
 COPY project/jsonschema.json TO checked_config.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_config.json
-REPLACE $CWD WITH '[CWD]' IN checked_config.json
-
 WRITE expected_config.json UNTIL EOF
 {
   "dependencies": {
@@ -69,8 +67,6 @@ COMPARE checked_config.json AGAINST expected_config.json
 
 COPY project/vendor/product.json TO checked_product.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_product.json
-REPLACE $CWD WITH '[CWD]' IN checked_product.json
-
 WRITE expected_product.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -86,8 +82,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH_USER
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_add_dependency_force.clitest
+++ b/test/install/pass_add_dependency_force.clitest
@@ -55,8 +55,6 @@ COMPARE result_1.txt AGAINST expected_1.txt
 
 COPY project/jsonschema.json TO checked_config.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_config.json
-REPLACE $CWD WITH '[CWD]' IN checked_config.json
-
 WRITE expected_config.json UNTIL EOF
 {
   "dependencies": {
@@ -70,8 +68,6 @@ COMPARE checked_config.json AGAINST expected_config.json
 
 COPY project/vendor/user.json TO checked_user.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_user.json
-REPLACE $CWD WITH '[CWD]' IN checked_user.json
-
 WRITE expected_user.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -84,8 +80,6 @@ COMPARE checked_user.json AGAINST expected_user.json
 
 COPY project/vendor/product.json TO checked_product.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_product.json
-REPLACE $CWD WITH '[CWD]' IN checked_product.json
-
 WRITE expected_product.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -101,8 +95,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH_USER
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_add_dependency_json.clitest
+++ b/test/install/pass_add_dependency_json.clitest
@@ -45,8 +45,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -59,8 +57,6 @@ COMPARE checked_schema.json AGAINST expected_schema.json
 
 COPY project/jsonschema.json TO checked_config.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_config.json
-REPLACE $CWD WITH '[CWD]' IN checked_config.json
-
 WRITE expected_config.json UNTIL EOF
 {
   "dependencies": {
@@ -75,8 +71,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_add_dependency_no_config.clitest
+++ b/test/install/pass_add_dependency_no_config.clitest
@@ -24,8 +24,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/jsonschema.json TO checked_config.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_config.json
-REPLACE $CWD WITH '[CWD]' IN checked_config.json
-
 WRITE expected_config.json UNTIL EOF
 {
   "dependencies": {
@@ -38,8 +36,6 @@ COMPARE checked_config.json AGAINST expected_config.json
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -54,8 +50,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_add_dependency_no_deps_key.clitest
+++ b/test/install/pass_add_dependency_no_deps_key.clitest
@@ -30,8 +30,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/jsonschema.json TO checked_file_1.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_file_1.txt
-REPLACE $CWD WITH '[CWD]' IN checked_file_1.txt
-
 WRITE expected_file_1.txt UNTIL EOF
 {
   "title": "test",
@@ -45,8 +43,6 @@ COMPARE checked_file_1.txt AGAINST expected_file_1.txt
 
 COPY project/vendor/user.json TO checked_file_2.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_file_2.txt
-REPLACE $CWD WITH '[CWD]' IN checked_file_2.txt
-
 WRITE expected_file_2.txt UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/install/pass_add_dependency_outside_path.clitest
+++ b/test/install/pass_add_dependency_outside_path.clitest
@@ -32,8 +32,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/jsonschema.json TO checked_config.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_config.json
-REPLACE $CWD WITH '[CWD]' IN checked_config.json
-
 WRITE expected_config.json UNTIL EOF
 {
   "dependencies": {
@@ -46,8 +44,6 @@ COMPARE checked_config.json AGAINST expected_config.json
 
 COPY external/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -62,8 +58,6 @@ CHECKSUM SHA256 external/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_add_dependency_overwrite.clitest
+++ b/test/install/pass_add_dependency_overwrite.clitest
@@ -34,8 +34,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/jsonschema.json TO checked_config.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_config.json
-REPLACE $CWD WITH '[CWD]' IN checked_config.json
-
 WRITE expected_config.json UNTIL EOF
 {
   "dependencies": {
@@ -48,8 +46,6 @@ COMPARE checked_config.json AGAINST expected_config.json
 
 COPY project/vendor/new_path.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -72,8 +68,6 @@ CHECKSUM SHA256 project/vendor/new_path.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_add_dependency_preserve_config.clitest
+++ b/test/install/pass_add_dependency_preserve_config.clitest
@@ -32,8 +32,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/jsonschema.json TO checked_config.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_config.json
-REPLACE $CWD WITH '[CWD]' IN checked_config.json
-
 WRITE expected_config.json UNTIL EOF
 {
   "path": ".",
@@ -48,8 +46,6 @@ COMPARE checked_config.json AGAINST expected_config.json
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -64,8 +60,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_add_dependency_subdir.clitest
+++ b/test/install/pass_add_dependency_subdir.clitest
@@ -30,8 +30,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/jsonschema.json TO checked_file_1.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_file_1.txt
-REPLACE $CWD WITH '[CWD]' IN checked_file_1.txt
-
 WRITE expected_file_1.txt UNTIL EOF
 {
   "dependencies": {
@@ -44,8 +42,6 @@ COMPARE checked_file_1.txt AGAINST expected_file_1.txt
 
 COPY project/vendor/user.json TO checked_file_2.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_file_2.txt
-REPLACE $CWD WITH '[CWD]' IN checked_file_2.txt
-
 WRITE expected_file_2.txt UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/install/pass_already_installed.clitest
+++ b/test/install/pass_already_installed.clitest
@@ -34,8 +34,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN install STDIN /dev/null IN project INTO result_1.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 2> Up to date     : [CWD_URI]/source/user.json
 EOF
@@ -44,8 +42,6 @@ COMPARE result_1.txt AGAINST expected_1.txt
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -60,8 +56,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_already_installed_json.clitest
+++ b/test/install/pass_already_installed_json.clitest
@@ -34,8 +34,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN install --json STDIN /dev/null IN project INTO result_1.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 1> {
 1>   "events": [
@@ -51,8 +49,6 @@ COMPARE result_1.txt AGAINST expected_1.txt
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -67,8 +63,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_configuration_option.clitest
+++ b/test/install/pass_configuration_option.clitest
@@ -35,8 +35,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY config/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -51,8 +49,6 @@ CHECKSUM SHA256 config/vendor/user.json AS HASH
 
 COPY config/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_configuration_option_add_dependency.clitest
+++ b/test/install/pass_configuration_option_add_dependency.clitest
@@ -26,8 +26,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/jsonschema.ci.json TO checked_config.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_config.json
-REPLACE $CWD WITH '[CWD]' IN checked_config.json
-
 WRITE expected_config.json UNTIL EOF
 {
   "dependencies": {
@@ -42,8 +40,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_corrupted_lock_invalid_format.clitest
+++ b/test/install/pass_corrupted_lock_invalid_format.clitest
@@ -41,8 +41,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/schema.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -57,8 +55,6 @@ CHECKSUM SHA256 project/vendor/schema.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_corrupted_lock_malformed.clitest
+++ b/test/install/pass_corrupted_lock_malformed.clitest
@@ -39,8 +39,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/schema.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -55,8 +53,6 @@ CHECKSUM SHA256 project/vendor/schema.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_corrupted_lock_malformed_json.clitest
+++ b/test/install/pass_corrupted_lock_malformed_json.clitest
@@ -52,8 +52,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/schema.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -68,8 +66,6 @@ CHECKSUM SHA256 project/vendor/schema.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_creates_parent_directories.clitest
+++ b/test/install/pass_creates_parent_directories.clitest
@@ -33,8 +33,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/deep/nested/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -49,8 +47,6 @@ CHECKSUM SHA256 project/deep/nested/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_debug_output.clitest
+++ b/test/install/pass_debug_output.clitest
@@ -45,8 +45,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -61,8 +59,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_dependency_as_metaschema.clitest
+++ b/test/install/pass_dependency_as_metaschema.clitest
@@ -57,8 +57,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/custom_meta.json TO checked_meta.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_meta.json
-REPLACE $CWD WITH '[CWD]' IN checked_meta.json
-
 WRITE expected_meta.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -75,8 +73,6 @@ COMPARE checked_meta.json AGAINST expected_meta.json
 
 COPY project/vendor/my_schema.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "[CWD_URI]/source/custom_meta.json",
@@ -108,8 +104,6 @@ CHECKSUM SHA256 project/vendor/my_schema.json AS HASH_SCHEMA
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_fetch_file_uri.clitest
+++ b/test/install/pass_fetch_file_uri.clitest
@@ -38,8 +38,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/schema.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -59,8 +57,6 @@ CHECKSUM SHA256 project/vendor/schema.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_fetch_file_uri_no_bundle_param.clitest
+++ b/test/install/pass_fetch_file_uri_no_bundle_param.clitest
@@ -33,8 +33,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/schema.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -49,8 +47,6 @@ CHECKSUM SHA256 project/vendor/schema.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_force_reinstall.clitest
+++ b/test/install/pass_force_reinstall.clitest
@@ -45,8 +45,6 @@ COMPARE result_1.txt AGAINST expected_1.txt
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -61,8 +59,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_frozen_idempotent.clitest
+++ b/test/install/pass_frozen_idempotent.clitest
@@ -36,8 +36,6 @@ COPY project/jsonschema.lock.json TO lock_before.json
 RUN install --frozen STDIN /dev/null IN project INTO result_1.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 2> Up to date     : [CWD_URI]/source/schema.json
 EOF
@@ -47,8 +45,6 @@ COMPARE result_1.txt AGAINST expected_1.txt
 RUN install --frozen STDIN /dev/null IN project INTO result_2.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_2.txt
-REPLACE $CWD WITH '[CWD]' IN result_2.txt
-
 WRITE expected_2.txt UNTIL EOF
 2> Up to date     : [CWD_URI]/source/schema.json
 EOF

--- a/test/install/pass_frozen_installs_missing.clitest
+++ b/test/install/pass_frozen_installs_missing.clitest
@@ -51,8 +51,6 @@ COMPARE project/jsonschema.lock.json AGAINST lock_before.json
 
 COPY project/vendor/schema.json TO checked_file_3.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_file_3.txt
-REPLACE $CWD WITH '[CWD]' IN checked_file_3.txt
-
 WRITE expected_file_3.txt UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/install/pass_frozen_installs_missing_creates_dirs.clitest
+++ b/test/install/pass_frozen_installs_missing_creates_dirs.clitest
@@ -51,8 +51,6 @@ COMPARE project/jsonschema.lock.json AGAINST lock_before.json
 
 COPY project/vendor/deep/nested/schema.json TO checked_file_3.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_file_3.txt
-REPLACE $CWD WITH '[CWD]' IN checked_file_3.txt
-
 WRITE expected_file_3.txt UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/install/pass_frozen_mixed_status.clitest
+++ b/test/install/pass_frozen_mixed_status.clitest
@@ -62,8 +62,6 @@ COMPARE project/jsonschema.lock.json AGAINST lock_before.json
 
 COPY project/vendor/user.json TO checked_file_3.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_file_3.txt
-REPLACE $CWD WITH '[CWD]' IN checked_file_3.txt
-
 WRITE expected_file_3.txt UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/install/pass_frozen_multiple_dependencies.clitest
+++ b/test/install/pass_frozen_multiple_dependencies.clitest
@@ -46,8 +46,6 @@ COPY project/jsonschema.lock.json TO lock_before.json
 RUN install --frozen STDIN /dev/null IN project INTO result_1.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 2> Up to date     : [CWD_URI]/source/product.json
 2> Up to date     : [CWD_URI]/source/user.json

--- a/test/install/pass_frozen_subdir.clitest
+++ b/test/install/pass_frozen_subdir.clitest
@@ -36,8 +36,6 @@ COPY project/jsonschema.lock.json TO lock_before.json
 RUN install --frozen STDIN /dev/null IN project/subdir INTO result_1.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 2> Up to date     : [CWD_URI]/source/schema.json
 EOF

--- a/test/install/pass_frozen_up_to_date.clitest
+++ b/test/install/pass_frozen_up_to_date.clitest
@@ -36,8 +36,6 @@ COPY project/jsonschema.lock.json TO lock_before.json
 RUN install --frozen STDIN /dev/null IN project INTO result_1.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 2> Up to date     : [CWD_URI]/source/schema.json
 EOF
@@ -48,8 +46,6 @@ COMPARE project/jsonschema.lock.json AGAINST lock_before.json
 
 COPY project/vendor/schema.json TO checked_file_3.txt
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_file_3.txt
-REPLACE $CWD WITH '[CWD]' IN checked_file_3.txt
-
 WRITE expected_file_3.txt UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/test/install/pass_frozen_up_to_date_json.clitest
+++ b/test/install/pass_frozen_up_to_date_json.clitest
@@ -26,8 +26,6 @@ COPY project/jsonschema.lock.json TO lock_before.json
 RUN install --frozen --json STDIN /dev/null IN project INTO result_1.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 1> {
 1>   "events": [

--- a/test/install/pass_header_does_not_break_file_uri.clitest
+++ b/test/install/pass_header_does_not_break_file_uri.clitest
@@ -33,8 +33,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -49,8 +47,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_lock_file_with_path.clitest
+++ b/test/install/pass_lock_file_with_path.clitest
@@ -34,8 +34,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -50,8 +48,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_multiple_dependencies.clitest
+++ b/test/install/pass_multiple_dependencies.clitest
@@ -43,8 +43,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/alpha.json TO checked_alpha.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_alpha.json
-REPLACE $CWD WITH '[CWD]' IN checked_alpha.json
-
 WRITE expected_alpha.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -57,8 +55,6 @@ COMPARE checked_alpha.json AGAINST expected_alpha.json
 
 COPY project/vendor/beta.json TO checked_beta.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_beta.json
-REPLACE $CWD WITH '[CWD]' IN checked_beta.json
-
 WRITE expected_beta.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -74,8 +70,6 @@ CHECKSUM SHA256 project/vendor/beta.json AS HASH_BETA
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_remove_orphaned_dependency.clitest
+++ b/test/install/pass_remove_orphaned_dependency.clitest
@@ -68,8 +68,6 @@ CHECKSUM SHA256 project/vendor/b.json AS HASH_B
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,
@@ -106,8 +104,6 @@ REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 RUN install STDIN /dev/null IN project INTO result_1.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 2> Up to date     : [CWD_URI]/source/a.json
 2> Orphaned       : [CWD_URI]/source/b.json
@@ -127,8 +123,6 @@ COMPARE project/vendor/a.json AGAINST expected_a.json
 
 COPY project/jsonschema.lock.json TO checked_lock_after.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock_after.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock_after.json
-
 WRITE expected_lock_after.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_remove_orphaned_dependency_json.clitest
+++ b/test/install/pass_remove_orphaned_dependency_json.clitest
@@ -56,8 +56,6 @@ REPLACE '[CWD_URI]' WITH $CWD_URI IN project/jsonschema.json
 RUN install --json STDIN /dev/null IN project INTO result_1.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 1> {
 1>   "events": [
@@ -97,8 +95,6 @@ CHECKSUM SHA256 project/vendor/a.json AS HASH_A
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_resolve_mapping.clitest
+++ b/test/install/pass_resolve_mapping.clitest
@@ -64,8 +64,6 @@ CHECKSUM SHA256 project/vendor/main.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_resolver_config_resolve_priority.clitest
+++ b/test/install/pass_resolver_config_resolve_priority.clitest
@@ -66,8 +66,6 @@ CHECKSUM SHA256 project/vendor/main.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_resolver_dependency_on_disk.clitest
+++ b/test/install/pass_resolver_dependency_on_disk.clitest
@@ -52,8 +52,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/meta.json TO checked_meta.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_meta.json
-REPLACE $CWD WITH '[CWD]' IN checked_meta.json
-
 WRITE expected_meta.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -70,8 +68,6 @@ COMPARE checked_meta.json AGAINST expected_meta.json
 
 COPY project/vendor/a.json TO checked_a.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_a.json
-REPLACE $CWD WITH '[CWD]' IN checked_a.json
-
 WRITE expected_a.json UNTIL EOF
 {
   "$schema": "[CWD_URI]/source/metaschema.json",
@@ -98,8 +94,6 @@ CHECKSUM SHA256 project/vendor/a.json AS HASH_A
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_resolver_file_uri_fallback.clitest
+++ b/test/install/pass_resolver_file_uri_fallback.clitest
@@ -52,8 +52,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/meta.json TO checked_meta.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_meta.json
-REPLACE $CWD WITH '[CWD]' IN checked_meta.json
-
 WRITE expected_meta.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -70,8 +68,6 @@ COMPARE checked_meta.json AGAINST expected_meta.json
 
 COPY project/vendor/a.json TO checked_a.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_a.json
-REPLACE $CWD WITH '[CWD]' IN checked_a.json
-
 WRITE expected_a.json UNTIL EOF
 {
   "$schema": "[CWD_URI]/source/metaschema.json",
@@ -98,8 +94,6 @@ CHECKSUM SHA256 project/vendor/meta.json AS HASH_META
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_resolver_official_schema.clitest
+++ b/test/install/pass_resolver_official_schema.clitest
@@ -35,8 +35,6 @@ CHECKSUM SHA256 project/vendor/schema.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,
@@ -57,8 +55,6 @@ COMPARE checked_lock.json AGAINST expected_lock.json
 RUN validate $CWD/project/vendor/schema.json $CWD/source/schema.json STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/install/pass_single_dependency.clitest
+++ b/test/install/pass_single_dependency.clitest
@@ -33,8 +33,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -49,8 +47,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_single_dependency_json.clitest
+++ b/test/install/pass_single_dependency_json.clitest
@@ -44,8 +44,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -60,8 +58,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_target_already_exists.clitest
+++ b/test/install/pass_target_already_exists.clitest
@@ -39,8 +39,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -55,8 +53,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/install/pass_verbose_output.clitest
+++ b/test/install/pass_verbose_output.clitest
@@ -36,8 +36,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 
 COPY project/vendor/user.json TO checked_schema.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_schema.json
-REPLACE $CWD WITH '[CWD]' IN checked_schema.json
-
 WRITE expected_schema.json UNTIL EOF
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -52,8 +50,6 @@ CHECKSUM SHA256 project/vendor/user.json AS HASH
 
 COPY project/jsonschema.lock.json TO checked_lock.json
 REPLACE $CWD_URI WITH '[CWD_URI]' IN checked_lock.json
-REPLACE $CWD WITH '[CWD]' IN checked_lock.json
-
 WRITE expected_lock.json UNTIL EOF
 {
   "version": 1,

--- a/test/metaschema/fail_directory.clitest
+++ b/test/metaschema/fail_directory.clitest
@@ -22,7 +22,7 @@ RUN metaschema schemas STDIN /dev/null IN . INTO result.txt EXPECTING 2
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
-2> fail: [CWD]/schemas/schema_2.json
+2> fail: schemas/schema_2.json
 2> error: Schema validation failure
 2>   The integer value 1 was expected to equal one of the following values: "array", "boolean", "integer", "null", "number", "object", and "string"
 2>     at instance location "/type" (line 5, column 3)

--- a/test/metaschema/fail_directory.clitest
+++ b/test/metaschema/fail_directory.clitest
@@ -19,8 +19,6 @@ EOF
 // Metaschema validation failure
 RUN metaschema schemas STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> fail: schemas/schema_2.json
 2> error: Schema validation failure

--- a/test/metaschema/fail_directory_json.clitest
+++ b/test/metaschema/fail_directory_json.clitest
@@ -65,8 +65,8 @@ WRITE expected.txt UNTIL EOF
 1>     }
 1>   ]
 1> }
-2> [CWD]/schemas/schema_1.json
-2> [CWD]/schemas/schema_2.json
+2> schemas/schema_1.json
+2> schemas/schema_2.json
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/fail_directory_json.clitest
+++ b/test/metaschema/fail_directory_json.clitest
@@ -19,8 +19,6 @@ EOF
 // Metaschema validation failure
 RUN metaschema schemas --json STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> {
 1>   "valid": true

--- a/test/metaschema/fail_format_assertion_flag.clitest
+++ b/test/metaschema/fail_format_assertion_flag.clitest
@@ -12,7 +12,7 @@ RUN metaschema schema.json --format-assertion STDIN /dev/null IN . INTO result.t
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
-2> fail: [CWD]/schema.json
+2> fail: schema.json
 2> error: Schema validation failure
 2>   The string value "has spaces in it" was expected to represent a valid URI reference
 2>     at instance location "/$dynamicRef" (line 3, column 3)

--- a/test/metaschema/fail_format_assertion_flag.clitest
+++ b/test/metaschema/fail_format_assertion_flag.clitest
@@ -9,8 +9,6 @@ EOF
 // Metaschema validation failure
 RUN metaschema schema.json --format-assertion STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> fail: schema.json
 2> error: Schema validation failure

--- a/test/metaschema/fail_json.clitest
+++ b/test/metaschema/fail_json.clitest
@@ -10,8 +10,6 @@ EOF
 // Metaschema validation failure
 RUN metaschema schema.json --json STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/metaschema/fail_json.clitest
+++ b/test/metaschema/fail_json.clitest
@@ -53,7 +53,7 @@ WRITE expected.txt UNTIL EOF
 1>     }
 1>   ]
 1> }
-2> [CWD]/schema.json
+2> schema.json
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/fail_single.clitest
+++ b/test/metaschema/fail_single.clitest
@@ -10,8 +10,6 @@ EOF
 // Metaschema validation failure
 RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> fail: schema.json
 2> error: Schema validation failure

--- a/test/metaschema/fail_single.clitest
+++ b/test/metaschema/fail_single.clitest
@@ -13,7 +13,7 @@ RUN metaschema schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 2
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
-2> fail: [CWD]/schema.json
+2> fail: schema.json
 2> error: Schema validation failure
 2>   The integer value 1 was expected to equal one of the following values: "array", "boolean", "integer", "null", "number", "object", and "string"
 2>     at instance location "/type" (line 5, column 3)

--- a/test/metaschema/fail_yaml.clitest
+++ b/test/metaschema/fail_yaml.clitest
@@ -6,8 +6,6 @@ EOF
 // Metaschema validation failure
 RUN metaschema schema.yaml STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> fail: schema.yaml
 2> error: Schema validation failure

--- a/test/metaschema/fail_yaml.clitest
+++ b/test/metaschema/fail_yaml.clitest
@@ -9,7 +9,7 @@ RUN metaschema schema.yaml STDIN /dev/null IN . INTO result.txt EXPECTING 2
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
-2> fail: [CWD]/schema.yaml
+2> fail: schema.yaml
 2> error: Schema validation failure
 2>   The integer value 1 was expected to equal one of the following values: "array", "boolean", "integer", "null", "number", "object", and "string"
 2>     at instance location "/type" (line 2, column 1)

--- a/test/metaschema/pass_2020_12_default_dialect_config.clitest
+++ b/test/metaschema/pass_2020_12_default_dialect_config.clitest
@@ -23,7 +23,7 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml
 2> Using extension: .yml
-2> ok: [CWD]/schema.json
+2> ok: schema.json
 2>   matches https://json-schema.org/draft/2020-12/schema
 2>
 2> 1 validated, 1 passed, 0 failed

--- a/test/metaschema/pass_2020_12_default_dialect_config.clitest
+++ b/test/metaschema/pass_2020_12_default_dialect_config.clitest
@@ -17,8 +17,6 @@ EOF
 
 RUN metaschema --verbose $CWD/schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml

--- a/test/metaschema/pass_2020_12_default_dialect_config_relative.clitest
+++ b/test/metaschema/pass_2020_12_default_dialect_config_relative.clitest
@@ -23,7 +23,7 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml
 2> Using extension: .yml
-2> ok: [CWD]/schema.json
+2> ok: schema.json
 2>   matches https://json-schema.org/draft/2020-12/schema
 2>
 2> 1 validated, 1 passed, 0 failed

--- a/test/metaschema/pass_2020_12_default_dialect_config_relative.clitest
+++ b/test/metaschema/pass_2020_12_default_dialect_config_relative.clitest
@@ -17,8 +17,6 @@ EOF
 
 RUN metaschema --verbose schema.json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml

--- a/test/metaschema/pass_config_path.clitest
+++ b/test/metaschema/pass_config_path.clitest
@@ -17,8 +17,6 @@ EOF
 
 RUN metaschema --verbose STDIN /dev/null IN bar INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml

--- a/test/metaschema/pass_config_path.clitest
+++ b/test/metaschema/pass_config_path.clitest
@@ -23,7 +23,7 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml
 2> Using extension: .yml
-2> ok: [CWD]/foo/schema.json
+2> ok: ../foo/schema.json
 2>   matches http://json-schema.org/draft-04/schema#
 2>
 2> 1 validated, 1 passed, 0 failed

--- a/test/metaschema/pass_config_path_debug.clitest
+++ b/test/metaschema/pass_config_path_debug.clitest
@@ -24,7 +24,7 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml
 2> Using extension: .yml
-2> ok: [CWD]/foo/schema.json
+2> ok: ../foo/schema.json
 2>   matches http://json-schema.org/draft-04/schema#
 2>
 2> 1 validated, 1 passed, 0 failed

--- a/test/metaschema/pass_configuration_option.clitest
+++ b/test/metaschema/pass_configuration_option.clitest
@@ -26,7 +26,7 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml
 2> Using extension: .yml
-2> ok: [CWD]/schema.json
+2> ok: schema.json
 2>   matches https://json-schema.org/draft/2020-12/schema
 2>
 2> 1 validated, 1 passed, 0 failed

--- a/test/metaschema/pass_custom_config_resolve.clitest
+++ b/test/metaschema/pass_custom_config_resolve.clitest
@@ -35,8 +35,6 @@ EOF
 
 RUN metaschema schema.json --verbose STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml

--- a/test/metaschema/pass_custom_config_resolve.clitest
+++ b/test/metaschema/pass_custom_config_resolve.clitest
@@ -41,7 +41,7 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml
 2> Using extension: .yml
-2> ok: [CWD]/schema.json
+2> ok: schema.json
 2>   matches https://example.com/meta
 2>
 2> 1 validated, 1 passed, 0 failed

--- a/test/metaschema/pass_cwd.clitest
+++ b/test/metaschema/pass_cwd.clitest
@@ -22,9 +22,9 @@ REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
 2> warning: Recursively processing every file in [CWD] as no input was provided
-2> ok: [CWD]/schema_1.json
+2> ok: schema_1.json
 2>   matches http://json-schema.org/draft-04/schema#
-2> ok: [CWD]/schema_2.json
+2> ok: schema_2.json
 2>   matches http://json-schema.org/draft-04/schema#
 2>
 2> 2 validated, 2 passed, 0 failed

--- a/test/metaschema/pass_cwd_config_no_path.clitest
+++ b/test/metaschema/pass_cwd_config_no_path.clitest
@@ -26,7 +26,7 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml
 2> Using extension: .yml
-2> ok: [CWD]/schema.json
+2> ok: schema.json
 2>   matches http://json-schema.org/draft-04/schema#
 2>
 2> 1 validated, 1 passed, 0 failed

--- a/test/metaschema/pass_extension_empty_json.clitest
+++ b/test/metaschema/pass_extension_empty_json.clitest
@@ -31,9 +31,9 @@ REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
 2> warning: Matching files with no extension
-2> ok: [CWD]/schemas/schema1
+2> ok: schemas/schema1
 2>   matches http://json-schema.org/draft-04/schema#
-2> ok: [CWD]/schemas/schema2
+2> ok: schemas/schema2
 2>   matches http://json-schema.org/draft-04/schema#
 2>
 2> 2 validated, 2 passed, 0 failed

--- a/test/metaschema/pass_extension_empty_json.clitest
+++ b/test/metaschema/pass_extension_empty_json.clitest
@@ -27,8 +27,6 @@ EOF
 
 RUN metaschema schemas --extension '' --verbose STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> warning: Matching files with no extension
 2> ok: schemas/schema1

--- a/test/metaschema/pass_extension_empty_yaml.clitest
+++ b/test/metaschema/pass_extension_empty_yaml.clitest
@@ -25,9 +25,9 @@ REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
 2> warning: Matching files with no extension
-2> ok: [CWD]/schemas/schema1
+2> ok: schemas/schema1
 2>   matches http://json-schema.org/draft-04/schema#
-2> ok: [CWD]/schemas/schema2
+2> ok: schemas/schema2
 2>   matches http://json-schema.org/draft-04/schema#
 2>
 2> 2 validated, 2 passed, 0 failed

--- a/test/metaschema/pass_extension_empty_yaml.clitest
+++ b/test/metaschema/pass_extension_empty_yaml.clitest
@@ -21,8 +21,6 @@ EOF
 
 RUN metaschema schemas --extension '' --verbose STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> warning: Matching files with no extension
 2> ok: schemas/schema1

--- a/test/metaschema/pass_json.clitest
+++ b/test/metaschema/pass_json.clitest
@@ -183,7 +183,7 @@ WRITE expected.txt UNTIL EOF
 1>     }
 1>   ]
 1> }
-2> [CWD]/schema.json
+2> schema.json
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/metaschema/pass_json.clitest
+++ b/test/metaschema/pass_json.clitest
@@ -14,8 +14,6 @@ EOF
 
 RUN metaschema schema.json --json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> {
 1>   "valid": true,

--- a/test/metaschema/pass_many_one_empty_directory.clitest
+++ b/test/metaschema/pass_many_one_empty_directory.clitest
@@ -15,7 +15,7 @@ RUN metaschema schemas extras --verbose STDIN /dev/null IN . INTO result_0.txt E
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/schemas/schema.json
+2> ok: schemas/schema.json
 2>   matches http://json-schema.org/draft-04/schema#
 2>
 2> 1 validated, 1 passed, 0 failed

--- a/test/metaschema/pass_many_one_empty_directory.clitest
+++ b/test/metaschema/pass_many_one_empty_directory.clitest
@@ -12,8 +12,6 @@ EOF
 
 RUN metaschema schemas extras --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: schemas/schema.json
 2>   matches http://json-schema.org/draft-04/schema#

--- a/test/rdf/fail_format_assertion.clitest
+++ b/test/rdf/fail_format_assertion.clitest
@@ -55,8 +55,6 @@ COMPARE result_1.txt AGAINST expected_1.txt
 RUN rdf schema.json instance.json --format-assertion --json STDIN /dev/null IN . INTO result_2.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_2.txt
-REPLACE $CWD WITH '[CWD]' IN result_2.txt
-
 WRITE expected_2.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/rdf/fail_invalid_instance.clitest
+++ b/test/rdf/fail_invalid_instance.clitest
@@ -37,8 +37,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN rdf schema.json instance.json --json STDIN /dev/null IN . INTO result_1.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/rdf/fail_invalid_instance_stdin.clitest
+++ b/test/rdf/fail_invalid_instance_stdin.clitest
@@ -27,8 +27,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN rdf schema.json - --json STDIN stdin_input IN . INTO result_1.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/validate/fail_2019_09.clitest
+++ b/test/validate/fail_2019_09.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_2019_09.clitest
+++ b/test/validate/fail_2019_09.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_2019_09_http.clitest
+++ b/test/validate/fail_2019_09_http.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_2019_09_http.clitest
+++ b/test/validate/fail_2019_09_http.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_2020_12.clitest
+++ b/test/validate/fail_2020_12.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_2020_12.clitest
+++ b/test/validate/fail_2020_12.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_2020_12_fast.clitest
+++ b/test/validate/fail_2020_12_fast.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json --fast STDIN /dev/null IN . INTO result_0
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>
 2> 1 validated, 0 passed, 1 failed

--- a/test/validate/fail_2020_12_fast.clitest
+++ b/test/validate/fail_2020_12_fast.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json --fast STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_2020_12_http.clitest
+++ b/test/validate/fail_2020_12_http.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_2020_12_http.clitest
+++ b/test/validate/fail_2020_12_http.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_2020_12_x_format_assertion.clitest
+++ b/test/validate/fail_2020_12_x_format_assertion.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The string value "not-an-email" was expected to represent a valid email address
 2>     at instance location "/email" (line 1, column 3)

--- a/test/validate/fail_2020_12_x_format_assertion.clitest
+++ b/test/validate/fail_2020_12_x_format_assertion.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_benchmark.clitest
+++ b/test/validate/fail_benchmark.clitest
@@ -19,7 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json --benchmark STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
 REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF

--- a/test/validate/fail_benchmark.clitest
+++ b/test/validate/fail_benchmark.clitest
@@ -24,7 +24,7 @@ REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH 
 
 WRITE expected_0.txt UNTIL EOF
 1> instance.json: FAIL [TIMING]
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 EOF
 

--- a/test/validate/fail_benchmark_jsonl.clitest
+++ b/test/validate/fail_benchmark_jsonl.clitest
@@ -16,7 +16,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.jsonl --benchmark STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
 REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF

--- a/test/validate/fail_benchmark_jsonl.clitest
+++ b/test/validate/fail_benchmark_jsonl.clitest
@@ -20,8 +20,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-1> [CWD]/instance.jsonl[1]: PASS [TIMING]
-1> [CWD]/instance.jsonl[2]: FAIL [TIMING]
+1> instance.jsonl[1]: PASS [TIMING]
+1> instance.jsonl[2]: FAIL [TIMING]
 2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 

--- a/test/validate/fail_benchmark_jsonl_continue.clitest
+++ b/test/validate/fail_benchmark_jsonl_continue.clitest
@@ -20,9 +20,9 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-1> [CWD]/instance.jsonl[1]: PASS [TIMING]
-1> [CWD]/instance.jsonl[2]: FAIL [TIMING]
-1> [CWD]/instance.jsonl[3]: PASS [TIMING]
+1> instance.jsonl[1]: PASS [TIMING]
+1> instance.jsonl[2]: FAIL [TIMING]
+1> instance.jsonl[3]: PASS [TIMING]
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_benchmark_jsonl_continue.clitest
+++ b/test/validate/fail_benchmark_jsonl_continue.clitest
@@ -16,7 +16,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.jsonl --benchmark --continue STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
 REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF

--- a/test/validate/fail_boolean_schema_false_default_dialect.clitest
+++ b/test/validate/fail_boolean_schema_false_default_dialect.clitest
@@ -12,7 +12,7 @@ RUN validate --default-dialect https://json-schema.org/draft/2020-12/schema sche
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>
 2> 1 validated, 0 passed, 1 failed

--- a/test/validate/fail_boolean_schema_false_default_dialect.clitest
+++ b/test/validate/fail_boolean_schema_false_default_dialect.clitest
@@ -9,8 +9,6 @@ EOF
 // Validation failure
 RUN validate --default-dialect https://json-schema.org/draft/2020-12/schema schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_directory.clitest
+++ b/test/validate/fail_directory.clitest
@@ -31,7 +31,7 @@ RUN validate schema.json instances STDIN /dev/null IN . INTO result_0.txt EXPECT
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instances/nested/instance_2.json
+2> fail: instances/nested/instance_2.json
 2> error: Schema validation failure
 2>   The value was expected to be of type integer but it was of type string
 2>     at instance location "/age" (line 1, column 18)

--- a/test/validate/fail_directory.clitest
+++ b/test/validate/fail_directory.clitest
@@ -28,8 +28,6 @@ EOF
 // Validation failure
 RUN validate schema.json instances STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instances/nested/instance_2.json
 2> error: Schema validation failure

--- a/test/validate/fail_directory_continue_json.clitest
+++ b/test/validate/fail_directory_continue_json.clitest
@@ -29,8 +29,6 @@ EOF
 RUN validate schema.json instances --json --continue STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/validate/fail_directory_continue_json.clitest
+++ b/test/validate/fail_directory_continue_json.clitest
@@ -54,8 +54,8 @@ WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "valid": true
 1> }
-2> [CWD]/instances/instance_1.json
-2> [CWD]/instances/instance_2.json
+2> instances/instance_1.json
+2> instances/instance_2.json
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_directory_continue_verbose.clitest
+++ b/test/validate/fail_directory_continue_verbose.clitest
@@ -25,8 +25,6 @@ EOF
 // Validation failure
 RUN validate schema.json instances --continue --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instances/instance_1.json
 2> error: Schema validation failure

--- a/test/validate/fail_directory_continue_verbose.clitest
+++ b/test/validate/fail_directory_continue_verbose.clitest
@@ -28,7 +28,7 @@ RUN validate schema.json instances --continue --verbose STDIN /dev/null IN . INT
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instances/instance_1.json
+2> fail: instances/instance_1.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)
@@ -36,8 +36,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
-2> ok: [CWD]/instances/instance_2.json
-2>   matches [CWD]/schema.json
+2> ok: instances/instance_2.json
+2>   matches schema.json
 2>
 2> 2 validated, 1 passed, 1 failed
 EOF

--- a/test/validate/fail_directory_fast.clitest
+++ b/test/validate/fail_directory_fast.clitest
@@ -28,7 +28,7 @@ RUN validate schema.json instances --fast STDIN /dev/null IN . INTO result_0.txt
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instances/instance_2.json
+2> fail: instances/instance_2.json
 2> error: Schema validation failure
 2>
 2> 2 validated, 1 passed, 1 failed

--- a/test/validate/fail_directory_fast.clitest
+++ b/test/validate/fail_directory_fast.clitest
@@ -25,8 +25,6 @@ EOF
 // Validation failure
 RUN validate schema.json instances --fast STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instances/instance_2.json
 2> error: Schema validation failure

--- a/test/validate/fail_directory_fast_json.clitest
+++ b/test/validate/fail_directory_fast_json.clitest
@@ -32,8 +32,8 @@ WRITE expected.txt UNTIL EOF
 1> {
 1>   "valid": false
 1> }
-2> [CWD]/instances/instance_1.json
-2> [CWD]/instances/instance_2.json
+2> instances/instance_1.json
+2> instances/instance_2.json
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/validate/fail_directory_fast_json.clitest
+++ b/test/validate/fail_directory_fast_json.clitest
@@ -23,8 +23,6 @@ EOF
 // Validation failure
 RUN validate schema.json instances --fast --json STDIN /dev/null IN . INTO result.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> {
 1>   "valid": true

--- a/test/validate/fail_directory_json.clitest
+++ b/test/validate/fail_directory_json.clitest
@@ -54,8 +54,8 @@ WRITE expected_0.txt UNTIL EOF
 1>     }
 1>   ]
 1> }
-2> [CWD]/instances/instance_1.json
-2> [CWD]/instances/instance_2.json
+2> instances/instance_1.json
+2> instances/instance_2.json
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/fail_directory_json.clitest
+++ b/test/validate/fail_directory_json.clitest
@@ -29,8 +29,6 @@ EOF
 RUN validate schema.json instances --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "valid": true

--- a/test/validate/fail_directory_stop_json.clitest
+++ b/test/validate/fail_directory_stop_json.clitest
@@ -51,7 +51,7 @@ WRITE expected_0.txt UNTIL EOF
 1>     }
 1>   ]
 1> }
-2> [CWD]/instances/instance_1.json
+2> instances/instance_1.json
 2> warning: Stopped at first failure, pass --continue/-c to keep going
 EOF
 

--- a/test/validate/fail_directory_stop_json.clitest
+++ b/test/validate/fail_directory_stop_json.clitest
@@ -29,8 +29,6 @@ EOF
 RUN validate schema.json instances --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/validate/fail_directory_stop_verbose.clitest
+++ b/test/validate/fail_directory_stop_verbose.clitest
@@ -28,7 +28,7 @@ RUN validate schema.json instances --verbose STDIN /dev/null IN . INTO result_0.
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instances/instance_1.json
+2> fail: instances/instance_1.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_directory_stop_verbose.clitest
+++ b/test/validate/fail_directory_stop_verbose.clitest
@@ -25,8 +25,6 @@ EOF
 // Validation failure
 RUN validate schema.json instances --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instances/instance_1.json
 2> error: Schema validation failure

--- a/test/validate/fail_directory_verbose.clitest
+++ b/test/validate/fail_directory_verbose.clitest
@@ -28,8 +28,6 @@ EOF
 // Validation failure
 RUN validate schema.json instances --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instances/instance_1.json
 2>   matches schema.json

--- a/test/validate/fail_directory_verbose.clitest
+++ b/test/validate/fail_directory_verbose.clitest
@@ -31,9 +31,9 @@ RUN validate schema.json instances --verbose STDIN /dev/null IN . INTO result_0.
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instances/instance_1.json
-2>   matches [CWD]/schema.json
-2> fail: [CWD]/instances/nested/instance_2.json
+2> ok: instances/instance_1.json
+2>   matches schema.json
+2> fail: instances/nested/instance_2.json
 2> error: Schema validation failure
 2>   The value was expected to be of type integer but it was of type string
 2>     at instance location "/age" (line 1, column 18)

--- a/test/validate/fail_draft3.clitest
+++ b/test/validate/fail_draft3.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_draft3.clitest
+++ b/test/validate/fail_draft3.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_draft3_https.clitest
+++ b/test/validate/fail_draft3_https.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_draft3_https.clitest
+++ b/test/validate/fail_draft3_https.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_draft4.clitest
+++ b/test/validate/fail_draft4.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_draft4.clitest
+++ b/test/validate/fail_draft4.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_draft4_https.clitest
+++ b/test/validate/fail_draft4_https.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_draft4_https.clitest
+++ b/test/validate/fail_draft4_https.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_draft4_x_format_assertion.clitest
+++ b/test/validate/fail_draft4_x_format_assertion.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The string value "not-an-email" was expected to represent a valid email address
 2>     at instance location "/email" (line 1, column 3)

--- a/test/validate/fail_draft4_x_format_assertion.clitest
+++ b/test/validate/fail_draft4_x_format_assertion.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_draft6.clitest
+++ b/test/validate/fail_draft6.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_draft6.clitest
+++ b/test/validate/fail_draft6.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_draft6_https.clitest
+++ b/test/validate/fail_draft6_https.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_draft6_https.clitest
+++ b/test/validate/fail_draft6_https.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_draft7.clitest
+++ b/test/validate/fail_draft7.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_draft7.clitest
+++ b/test/validate/fail_draft7.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_draft7_https.clitest
+++ b/test/validate/fail_draft7_https.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_draft7_https.clitest
+++ b/test/validate/fail_draft7_https.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_entrypoint_mismatch.clitest
+++ b/test/validate/fail_entrypoint_mismatch.clitest
@@ -22,7 +22,7 @@ REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The integer value -5 was expected to be greater than or equal to the integer 1
 2>     at instance location "" (line 1, column 1)

--- a/test/validate/fail_entrypoint_mismatch.clitest
+++ b/test/validate/fail_entrypoint_mismatch.clitest
@@ -19,8 +19,6 @@ EOF
 RUN validate schema.json instance.json --entrypoint /\$$defs/PositiveInt --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure
@@ -37,8 +35,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN validate schema.json instance.json --entrypoint /\$$defs/PositiveInt --json STDIN /dev/null IN . INTO result_1.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/validate/fail_format_assertion_flag.clitest
+++ b/test/validate/fail_format_assertion_flag.clitest
@@ -16,7 +16,7 @@ RUN validate schema.json instance.json --format-assertion STDIN /dev/null IN . I
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The string value "not-an-email" was expected to represent a valid email address
 2>     at instance location "" (line 1, column 1)

--- a/test/validate/fail_format_assertion_flag.clitest
+++ b/test/validate/fail_format_assertion_flag.clitest
@@ -13,8 +13,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.json --format-assertion STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_json.clitest
+++ b/test/validate/fail_json.clitest
@@ -20,8 +20,6 @@ EOF
 RUN validate schema.json instance.json --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/validate/fail_jsonl_all.clitest
+++ b/test/validate/fail_jsonl_all.clitest
@@ -16,8 +16,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.jsonl STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.jsonl (entry #1)
 2>

--- a/test/validate/fail_jsonl_all.clitest
+++ b/test/validate/fail_jsonl_all.clitest
@@ -19,7 +19,7 @@ RUN validate schema.json instance.jsonl STDIN /dev/null IN . INTO result_0.txt E
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.jsonl (entry #1)
+2> fail: instance.jsonl (entry #1)
 2>
 2> {
 2>   "foo": 1

--- a/test/validate/fail_jsonl_all_continue.clitest
+++ b/test/validate/fail_jsonl_all_continue.clitest
@@ -19,7 +19,7 @@ RUN validate schema.json instance.jsonl --continue STDIN /dev/null IN . INTO res
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.jsonl (entry #1)
+2> fail: instance.jsonl (entry #1)
 2>
 2> {
 2>   "foo": 1
@@ -30,7 +30,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location ""
 2>     at evaluate path "/type"
 2>
-2> fail: [CWD]/instance.jsonl (entry #2)
+2> fail: instance.jsonl (entry #2)
 2>
 2> {
 2>   "foo": 2
@@ -41,7 +41,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location ""
 2>     at evaluate path "/type"
 2>
-2> fail: [CWD]/instance.jsonl (entry #3)
+2> fail: instance.jsonl (entry #3)
 2>
 2> {
 2>   "foo": 3

--- a/test/validate/fail_jsonl_all_continue.clitest
+++ b/test/validate/fail_jsonl_all_continue.clitest
@@ -16,8 +16,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.jsonl --continue STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.jsonl (entry #1)
 2>

--- a/test/validate/fail_jsonl_all_continue_verbose.clitest
+++ b/test/validate/fail_jsonl_all_continue_verbose.clitest
@@ -20,7 +20,7 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as JSONL: [CWD]/instance.jsonl
-2> fail: [CWD]/instance.jsonl (entry #1)
+2> fail: instance.jsonl (entry #1)
 2>
 2> {
 2>   "foo": 1
@@ -31,7 +31,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location ""
 2>     at evaluate path "/type"
 2>
-2> fail: [CWD]/instance.jsonl (entry #2)
+2> fail: instance.jsonl (entry #2)
 2>
 2> {
 2>   "foo": 2
@@ -42,7 +42,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location ""
 2>     at evaluate path "/type"
 2>
-2> fail: [CWD]/instance.jsonl (entry #3)
+2> fail: instance.jsonl (entry #3)
 2>
 2> {
 2>   "foo": 3

--- a/test/validate/fail_jsonl_all_verbose.clitest
+++ b/test/validate/fail_jsonl_all_verbose.clitest
@@ -20,7 +20,7 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as JSONL: [CWD]/instance.jsonl
-2> fail: [CWD]/instance.jsonl (entry #1)
+2> fail: instance.jsonl (entry #1)
 2>
 2> {
 2>   "foo": 1

--- a/test/validate/fail_jsonl_continue.clitest
+++ b/test/validate/fail_jsonl_continue.clitest
@@ -16,8 +16,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.jsonl --continue STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.jsonl (entry #2)
 2>

--- a/test/validate/fail_jsonl_continue.clitest
+++ b/test/validate/fail_jsonl_continue.clitest
@@ -19,7 +19,7 @@ RUN validate schema.json instance.jsonl --continue STDIN /dev/null IN . INTO res
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.jsonl (entry #2)
+2> fail: instance.jsonl (entry #2)
 2>
 2> [
 2>   {
@@ -32,7 +32,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location ""
 2>     at evaluate path "/type"
 2>
-2> fail: [CWD]/instance.jsonl (entry #3)
+2> fail: instance.jsonl (entry #3)
 2>
 2> 42
 2>

--- a/test/validate/fail_jsonl_continue_json.clitest
+++ b/test/validate/fail_jsonl_continue_json.clitest
@@ -17,8 +17,6 @@ EOF
 RUN validate schema.json instance.jsonl --json --continue STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "valid": true

--- a/test/validate/fail_jsonl_continue_verbose.clitest
+++ b/test/validate/fail_jsonl_continue_verbose.clitest
@@ -20,9 +20,9 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as JSONL: [CWD]/instance.jsonl
-2> ok: [CWD]/instance.jsonl (entry #1)
-2>   matches [CWD]/schema.json
-2> fail: [CWD]/instance.jsonl (entry #2)
+2> ok: instance.jsonl (entry #1)
+2>   matches schema.json
+2> fail: instance.jsonl (entry #2)
 2>
 2> [
 2>   {
@@ -35,7 +35,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location ""
 2>     at evaluate path "/type"
 2>
-2> fail: [CWD]/instance.jsonl (entry #3)
+2> fail: instance.jsonl (entry #3)
 2>
 2> 42
 2>

--- a/test/validate/fail_jsonl_gz_continue.clitest
+++ b/test/validate/fail_jsonl_gz_continue.clitest
@@ -18,8 +18,6 @@ COMPRESS GZIP instance.jsonl INTO instance.jsonl.gz
 // Validation failure
 RUN validate schema.json instance.jsonl.gz --continue STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.jsonl.gz (entry #1)
 2>

--- a/test/validate/fail_jsonl_gz_continue.clitest
+++ b/test/validate/fail_jsonl_gz_continue.clitest
@@ -21,7 +21,7 @@ RUN validate schema.json instance.jsonl.gz --continue STDIN /dev/null IN . INTO 
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.jsonl.gz (entry #1)
+2> fail: instance.jsonl.gz (entry #1)
 2>
 2> {
 2>   "foo": 1
@@ -32,7 +32,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location ""
 2>     at evaluate path "/type"
 2>
-2> fail: [CWD]/instance.jsonl.gz (entry #2)
+2> fail: instance.jsonl.gz (entry #2)
 2>
 2> {
 2>   "foo": 2
@@ -43,7 +43,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location ""
 2>     at evaluate path "/type"
 2>
-2> fail: [CWD]/instance.jsonl.gz (entry #3)
+2> fail: instance.jsonl.gz (entry #3)
 2>
 2> {
 2>   "foo": 3

--- a/test/validate/fail_jsonl_gz_continue_json.clitest
+++ b/test/validate/fail_jsonl_gz_continue_json.clitest
@@ -19,8 +19,6 @@ COMPRESS GZIP instance.jsonl INTO instance.jsonl.gz
 RUN validate schema.json instance.jsonl.gz --json --continue STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/validate/fail_jsonl_gz_continue_verbose.clitest
+++ b/test/validate/fail_jsonl_gz_continue_verbose.clitest
@@ -22,7 +22,7 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as GZIP-compressed JSONL: [CWD]/instance.jsonl.gz
-2> fail: [CWD]/instance.jsonl.gz (entry #1)
+2> fail: instance.jsonl.gz (entry #1)
 2>
 2> {
 2>   "foo": 1
@@ -33,7 +33,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location ""
 2>     at evaluate path "/type"
 2>
-2> fail: [CWD]/instance.jsonl.gz (entry #2)
+2> fail: instance.jsonl.gz (entry #2)
 2>
 2> {
 2>   "foo": 2
@@ -44,7 +44,7 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location ""
 2>     at evaluate path "/type"
 2>
-2> fail: [CWD]/instance.jsonl.gz (entry #3)
+2> fail: instance.jsonl.gz (entry #3)
 2>
 2> {
 2>   "foo": 3

--- a/test/validate/fail_jsonl_gz_one.clitest
+++ b/test/validate/fail_jsonl_gz_one.clitest
@@ -18,8 +18,6 @@ COMPRESS GZIP instance.jsonl INTO instance.jsonl.gz
 // Validation failure
 RUN validate schema.json instance.jsonl.gz STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.jsonl.gz (entry #2)
 2>

--- a/test/validate/fail_jsonl_gz_one.clitest
+++ b/test/validate/fail_jsonl_gz_one.clitest
@@ -21,7 +21,7 @@ RUN validate schema.json instance.jsonl.gz STDIN /dev/null IN . INTO result_0.tx
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.jsonl.gz (entry #2)
+2> fail: instance.jsonl.gz (entry #2)
 2>
 2> [
 2>   {

--- a/test/validate/fail_jsonl_gz_one_json.clitest
+++ b/test/validate/fail_jsonl_gz_one_json.clitest
@@ -19,8 +19,6 @@ COMPRESS GZIP instance.jsonl INTO instance.jsonl.gz
 RUN validate schema.json instance.jsonl.gz --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "valid": true

--- a/test/validate/fail_jsonl_gz_one_verbose.clitest
+++ b/test/validate/fail_jsonl_gz_one_verbose.clitest
@@ -22,9 +22,9 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as GZIP-compressed JSONL: [CWD]/instance.jsonl.gz
-2> ok: [CWD]/instance.jsonl.gz (entry #1)
-2>   matches [CWD]/schema.json
-2> fail: [CWD]/instance.jsonl.gz (entry #2)
+2> ok: instance.jsonl.gz (entry #1)
+2>   matches schema.json
+2> fail: instance.jsonl.gz (entry #2)
 2>
 2> [
 2>   {

--- a/test/validate/fail_jsonl_one.clitest
+++ b/test/validate/fail_jsonl_one.clitest
@@ -19,7 +19,7 @@ RUN validate schema.json instance.jsonl STDIN /dev/null IN . INTO result_0.txt E
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.jsonl (entry #2)
+2> fail: instance.jsonl (entry #2)
 2>
 2> [
 2>   {

--- a/test/validate/fail_jsonl_one.clitest
+++ b/test/validate/fail_jsonl_one.clitest
@@ -16,8 +16,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.jsonl STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.jsonl (entry #2)
 2>

--- a/test/validate/fail_jsonl_one_continue.clitest
+++ b/test/validate/fail_jsonl_one_continue.clitest
@@ -16,8 +16,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.jsonl --continue STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.jsonl (entry #2)
 2>

--- a/test/validate/fail_jsonl_one_continue.clitest
+++ b/test/validate/fail_jsonl_one_continue.clitest
@@ -19,7 +19,7 @@ RUN validate schema.json instance.jsonl --continue STDIN /dev/null IN . INTO res
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.jsonl (entry #2)
+2> fail: instance.jsonl (entry #2)
 2>
 2> [
 2>   {

--- a/test/validate/fail_jsonl_one_continue_verbose.clitest
+++ b/test/validate/fail_jsonl_one_continue_verbose.clitest
@@ -20,9 +20,9 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as JSONL: [CWD]/instance.jsonl
-2> ok: [CWD]/instance.jsonl (entry #1)
-2>   matches [CWD]/schema.json
-2> fail: [CWD]/instance.jsonl (entry #2)
+2> ok: instance.jsonl (entry #1)
+2>   matches schema.json
+2> fail: instance.jsonl (entry #2)
 2>
 2> [
 2>   {
@@ -35,8 +35,8 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location ""
 2>     at evaluate path "/type"
 2>
-2> ok: [CWD]/instance.jsonl (entry #3)
-2>   matches [CWD]/schema.json
+2> ok: instance.jsonl (entry #3)
+2>   matches schema.json
 2>
 2> 3 validated, 2 passed, 1 failed
 EOF

--- a/test/validate/fail_jsonl_one_json.clitest
+++ b/test/validate/fail_jsonl_one_json.clitest
@@ -17,8 +17,6 @@ EOF
 RUN validate schema.json instance.jsonl --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "valid": true

--- a/test/validate/fail_jsonl_one_verbose.clitest
+++ b/test/validate/fail_jsonl_one_verbose.clitest
@@ -20,9 +20,9 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as JSONL: [CWD]/instance.jsonl
-2> ok: [CWD]/instance.jsonl (entry #1)
-2>   matches [CWD]/schema.json
-2> fail: [CWD]/instance.jsonl (entry #2)
+2> ok: instance.jsonl (entry #1)
+2>   matches schema.json
+2> fail: instance.jsonl (entry #2)
 2>
 2> [
 2>   {

--- a/test/validate/fail_many.clitest
+++ b/test/validate/fail_many.clitest
@@ -30,7 +30,7 @@ RUN validate schema.json instance_1.json instance_2.json instance_3.json STDIN /
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance_2.json
+2> fail: instance_2.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_many.clitest
+++ b/test/validate/fail_many.clitest
@@ -27,8 +27,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance_1.json instance_2.json instance_3.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance_2.json
 2> error: Schema validation failure

--- a/test/validate/fail_many_continue_verbose.clitest
+++ b/test/validate/fail_many_continue_verbose.clitest
@@ -30,9 +30,9 @@ RUN validate schema.json instance_1.json instance_2.json instance_3.json --conti
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance_1.json
-2>   matches [CWD]/schema.json
-2> fail: [CWD]/instance_2.json
+2> ok: instance_1.json
+2>   matches schema.json
+2> fail: instance_2.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)
@@ -40,8 +40,8 @@ WRITE expected_0.txt UNTIL EOF
 2>   The object value was expected to validate against the single defined property subschema
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
-2> ok: [CWD]/instance_3.json
-2>   matches [CWD]/schema.json
+2> ok: instance_3.json
+2>   matches schema.json
 2>
 2> 3 validated, 2 passed, 1 failed
 EOF

--- a/test/validate/fail_many_continue_verbose.clitest
+++ b/test/validate/fail_many_continue_verbose.clitest
@@ -27,8 +27,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance_1.json instance_2.json instance_3.json --continue --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance_1.json
 2>   matches schema.json

--- a/test/validate/fail_many_verbose.clitest
+++ b/test/validate/fail_many_verbose.clitest
@@ -27,8 +27,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance_1.json instance_2.json instance_3.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance_1.json
 2>   matches schema.json

--- a/test/validate/fail_many_verbose.clitest
+++ b/test/validate/fail_many_verbose.clitest
@@ -30,9 +30,9 @@ RUN validate schema.json instance_1.json instance_2.json instance_3.json --verbo
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance_1.json
-2>   matches [CWD]/schema.json
-2> fail: [CWD]/instance_2.json
+2> ok: instance_1.json
+2>   matches schema.json
+2> fail: instance_2.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_stdin_instance.clitest
+++ b/test/validate/fail_stdin_instance.clitest
@@ -28,8 +28,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN validate schema.json - --json STDIN stdin_input IN . INTO result_1.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/validate/fail_stdin_instance_trace.clitest
+++ b/test/validate/fail_stdin_instance_trace.clitest
@@ -13,8 +13,6 @@ EOF
 RUN validate schema.json - --trace STDIN stdin_0 IN . INTO result.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> -> (push) "/type" (AssertionTypeStrict)
 1>    at instance location "" (line 1, column 1)

--- a/test/validate/fail_stdin_schema_validation.clitest
+++ b/test/validate/fail_stdin_schema_validation.clitest
@@ -13,8 +13,6 @@ EOF
 // Validation failure
 RUN validate - instance.json STDIN stdin_0 IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_stdin_schema_validation.clitest
+++ b/test/validate/fail_stdin_schema_validation.clitest
@@ -16,7 +16,7 @@ RUN validate - instance.json STDIN stdin_0 IN . INTO result_0.txt EXPECTING 2
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "" (line 1, column 1)

--- a/test/validate/fail_stdin_schema_validation_no_id.clitest
+++ b/test/validate/fail_stdin_schema_validation_no_id.clitest
@@ -15,7 +15,7 @@ RUN validate - instance.json STDIN stdin_0 IN . INTO result_0.txt EXPECTING 2
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.json
+2> fail: instance.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "" (line 1, column 1)

--- a/test/validate/fail_stdin_schema_validation_no_id.clitest
+++ b/test/validate/fail_stdin_schema_validation_no_id.clitest
@@ -12,8 +12,6 @@ EOF
 // Validation failure
 RUN validate - instance.json STDIN stdin_0 IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.json
 2> error: Schema validation failure

--- a/test/validate/fail_stdin_yaml_input.clitest
+++ b/test/validate/fail_stdin_yaml_input.clitest
@@ -29,8 +29,6 @@ COMPARE result_0.txt AGAINST expected_0.txt
 RUN validate schema.json - --json STDIN stdin_input IN . INTO result_1.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_1.txt
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
-
 WRITE expected_1.txt UNTIL EOF
 1> {
 1>   "valid": false,

--- a/test/validate/fail_trace.clitest
+++ b/test/validate/fail_trace.clitest
@@ -19,8 +19,6 @@ EOF
 RUN validate schema.json instance.json --trace STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> @- (annotation) "/description" (AnnotationEmit)
 1>    value "Test schema"

--- a/test/validate/fail_trace_fast.clitest
+++ b/test/validate/fail_trace_fast.clitest
@@ -19,8 +19,6 @@ EOF
 RUN validate schema.json instance.json --trace --fast STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> -> (push) "/properties/foo/type" (AssertionPropertyTypeStrict)
 1>    at instance location "/foo" (line 1, column 3)

--- a/test/validate/fail_yaml.clitest
+++ b/test/validate/fail_yaml.clitest
@@ -16,7 +16,7 @@ RUN validate schema.yaml instance.yaml STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.yaml
+2> fail: instance.yaml
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
 2>     at instance location "/foo" (line 1, column 1)

--- a/test/validate/fail_yaml.clitest
+++ b/test/validate/fail_yaml.clitest
@@ -13,8 +13,6 @@ EOF
 // Validation failure
 RUN validate schema.yaml instance.yaml STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.yaml
 2> error: Schema validation failure

--- a/test/validate/fail_yaml_multi_blank_lines.clitest
+++ b/test/validate/fail_yaml_multi_blank_lines.clitest
@@ -25,9 +25,9 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as YAML multi-document: [CWD]/instance.yaml
-2> ok: [CWD]/instance.yaml (entry #1)
-2>   matches [CWD]/schema.json
-2> fail: [CWD]/instance.yaml (entry #2)
+2> ok: instance.yaml (entry #1)
+2>   matches schema.json
+2> fail: instance.yaml (entry #2)
 2>
 2> [
 2>   {

--- a/test/validate/fail_yaml_multi_one.clitest
+++ b/test/validate/fail_yaml_multi_one.clitest
@@ -22,7 +22,7 @@ RUN validate schema.json instance.yaml STDIN /dev/null IN . INTO result_0.txt EX
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> fail: [CWD]/instance.yaml (entry #2)
+2> fail: instance.yaml (entry #2)
 2>
 2> [
 2>   {

--- a/test/validate/fail_yaml_multi_one.clitest
+++ b/test/validate/fail_yaml_multi_one.clitest
@@ -19,8 +19,6 @@ EOF
 // Validation failure
 RUN validate schema.json instance.yaml STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> fail: instance.yaml (entry #2)
 2>

--- a/test/validate/fail_yaml_multi_one_json.clitest
+++ b/test/validate/fail_yaml_multi_one_json.clitest
@@ -20,8 +20,6 @@ EOF
 RUN validate schema.json instance.yaml --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "valid": true

--- a/test/validate/fail_yaml_multi_one_verbose.clitest
+++ b/test/validate/fail_yaml_multi_one_verbose.clitest
@@ -23,9 +23,9 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as YAML multi-document: [CWD]/instance.yaml
-2> ok: [CWD]/instance.yaml (entry #1)
-2>   matches [CWD]/schema.json
-2> fail: [CWD]/instance.yaml (entry #2)
+2> ok: instance.yaml (entry #1)
+2>   matches schema.json
+2> fail: instance.yaml (entry #2)
 2>
 2> [
 2>   {

--- a/test/validate/pass_2020_12_default_dialect_config.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config.clitest
@@ -20,8 +20,6 @@ EOF
 
 RUN validate --verbose $CWD/schema.json $CWD/instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_2020_12_default_dialect_config.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config.clitest
@@ -23,8 +23,8 @@ RUN validate --verbose $CWD/schema.json $CWD/instance.json STDIN /dev/null IN . 
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_2020_12_default_dialect_config_parent.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config_parent.clitest
@@ -22,8 +22,6 @@ EOF
 
 RUN validate --verbose level1/level2/level3/schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches level1/level2/level3/schema.json

--- a/test/validate/pass_2020_12_default_dialect_config_parent.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config_parent.clitest
@@ -25,8 +25,8 @@ RUN validate --verbose level1/level2/level3/schema.json instance.json STDIN /dev
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/level1/level2/level3/schema.json
+2> ok: instance.json
+2>   matches level1/level2/level3/schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_2020_12_default_dialect_config_relative.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config_relative.clitest
@@ -20,8 +20,6 @@ EOF
 
 RUN validate --verbose schema.json instance.json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_2020_12_default_dialect_config_relative.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config_relative.clitest
@@ -23,8 +23,8 @@ RUN validate --verbose schema.json instance.json STDIN /dev/null IN . INTO resul
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_2020_12_format_assertion.clitest
+++ b/test/validate/pass_2020_12_format_assertion.clitest
@@ -33,8 +33,8 @@ RUN validate schema.json instance.json --resolve metaschema.json --verbose STDIN
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_2020_12_format_assertion.clitest
+++ b/test/validate/pass_2020_12_format_assertion.clitest
@@ -30,8 +30,6 @@ EOF
 
 RUN validate schema.json instance.json --resolve metaschema.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_2020_12_format_assertion_optional.clitest
+++ b/test/validate/pass_2020_12_format_assertion_optional.clitest
@@ -33,8 +33,8 @@ RUN validate schema.json instance.json --resolve metaschema.json --verbose STDIN
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_2020_12_format_assertion_optional.clitest
+++ b/test/validate/pass_2020_12_format_assertion_optional.clitest
@@ -30,8 +30,6 @@ EOF
 
 RUN validate schema.json instance.json --resolve metaschema.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_benchmark_loop_jsonl.clitest
+++ b/test/validate/pass_benchmark_loop_jsonl.clitest
@@ -19,9 +19,9 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-1> [CWD]/instance.jsonl[1]: PASS [TIMING]
-1> [CWD]/instance.jsonl[2]: PASS [TIMING]
-1> [CWD]/instance.jsonl[3]: PASS [TIMING]
+1> instance.jsonl[1]: PASS [TIMING]
+1> instance.jsonl[2]: PASS [TIMING]
+1> instance.jsonl[3]: PASS [TIMING]
 EOF
 
 COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/validate/pass_benchmark_loop_jsonl.clitest
+++ b/test/validate/pass_benchmark_loop_jsonl.clitest
@@ -15,7 +15,6 @@ EOF
 
 RUN validate schema.json instance.jsonl --benchmark --loop 1000 STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
 REPLACE MATCHING '[0-9]+\.[0-9]+ \+- [0-9]+\.[0-9]+ us \([0-9]+\.[0-9]+\)' WITH '[TIMING]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF

--- a/test/validate/pass_config_ignore_with_cli.clitest
+++ b/test/validate/pass_config_ignore_with_cli.clitest
@@ -48,8 +48,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml
 2> Using extension: .yml
-2> ok: [CWD]/instances/valid.json
-2>   matches [CWD]/schema.json
+2> ok: instances/valid.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_configuration_option.clitest
+++ b/test/validate/pass_configuration_option.clitest
@@ -26,8 +26,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_configuration_option_custom_name.clitest
+++ b/test/validate/pass_configuration_option_custom_name.clitest
@@ -24,8 +24,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/jsonschema.ci.json
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_configuration_option_directory.clitest
+++ b/test/validate/pass_configuration_option_directory.clitest
@@ -26,8 +26,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_configuration_option_over_discovered.clitest
+++ b/test/validate/pass_configuration_option_over_discovered.clitest
@@ -32,8 +32,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_configuration_option_short.clitest
+++ b/test/validate/pass_configuration_option_short.clitest
@@ -26,8 +26,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_cwd.clitest
+++ b/test/validate/pass_cwd.clitest
@@ -26,12 +26,12 @@ REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
 2> warning: Recursively processing every file in [CWD] as no input was provided
-2> ok: [CWD]/instance_1.json
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instance_2.json
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/schema.json
-2>   matches [CWD]/schema.json
+2> ok: instance_1.json
+2>   matches schema.json
+2> ok: instance_2.json
+2>   matches schema.json
+2> ok: schema.json
+2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF

--- a/test/validate/pass_cwd_config_no_path.clitest
+++ b/test/validate/pass_cwd_config_no_path.clitest
@@ -35,10 +35,10 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml
 2> Using extension: .yml
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/schema.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
+2> ok: schema.json
+2>   matches schema.json
 2>
 2> 2 validated, 2 passed, 0 failed
 EOF

--- a/test/validate/pass_default_dialect_cli_relative.clitest
+++ b/test/validate/pass_default_dialect_cli_relative.clitest
@@ -24,8 +24,6 @@ EOF
 
 RUN validate schema.json instance.json --default-dialect ../meta.json --verbose STDIN /dev/null IN sub INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_default_dialect_cli_relative.clitest
+++ b/test/validate/pass_default_dialect_cli_relative.clitest
@@ -27,8 +27,8 @@ RUN validate schema.json instance.json --default-dialect ../meta.json --verbose 
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/sub/instance.json
-2>   matches [CWD]/sub/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_directory_extension_verbose.clitest
+++ b/test/validate/pass_directory_extension_verbose.clitest
@@ -27,8 +27,6 @@ EOF
 
 RUN validate schema.json instances --extension .data.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> Using extension: .data.json
 2> ok: instances/instance_1.data.json

--- a/test/validate/pass_directory_extension_verbose.clitest
+++ b/test/validate/pass_directory_extension_verbose.clitest
@@ -31,10 +31,10 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Using extension: .data.json
-2> ok: [CWD]/instances/instance_1.data.json
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instances/instance_2.data.json
-2>   matches [CWD]/schema.json
+2> ok: instances/instance_1.data.json
+2>   matches schema.json
+2> ok: instances/instance_2.data.json
+2>   matches schema.json
 2>
 2> 2 validated, 2 passed, 0 failed
 EOF

--- a/test/validate/pass_directory_fast_json.clitest
+++ b/test/validate/pass_directory_fast_json.clitest
@@ -22,8 +22,6 @@ EOF
 
 RUN validate schema.json instances --fast --json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> {
 1>   "valid": true

--- a/test/validate/pass_directory_fast_json.clitest
+++ b/test/validate/pass_directory_fast_json.clitest
@@ -31,8 +31,8 @@ WRITE expected.txt UNTIL EOF
 1> {
 1>   "valid": true
 1> }
-2> [CWD]/instances/instance_1.json
-2> [CWD]/instances/instance_2.json
+2> instances/instance_1.json
+2> instances/instance_2.json
 EOF
 
 COMPARE result.txt AGAINST expected.txt

--- a/test/validate/pass_directory_ignore_verbose.clitest
+++ b/test/validate/pass_directory_ignore_verbose.clitest
@@ -27,8 +27,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Ignoring path: "[CWD]/instances/drafts"
-2> ok: [CWD]/instances/instance_1.json
-2>   matches [CWD]/schema.json
+2> ok: instances/instance_1.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_directory_verbose.clitest
+++ b/test/validate/pass_directory_verbose.clitest
@@ -26,8 +26,6 @@ EOF
 
 RUN validate schema.json instances --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instances/instance_1.json
 2>   matches schema.json

--- a/test/validate/pass_directory_verbose.clitest
+++ b/test/validate/pass_directory_verbose.clitest
@@ -29,10 +29,10 @@ RUN validate schema.json instances --verbose STDIN /dev/null IN . INTO result_0.
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instances/instance_1.json
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instances/instance_2.json
-2>   matches [CWD]/schema.json
+2> ok: instances/instance_1.json
+2>   matches schema.json
+2> ok: instances/instance_2.json
+2>   matches schema.json
 2>
 2> 2 validated, 2 passed, 0 failed
 EOF

--- a/test/validate/pass_entrypoint_pointer.clitest
+++ b/test/validate/pass_entrypoint_pointer.clitest
@@ -17,8 +17,6 @@ EOF
 
 RUN validate schema.json instance.json --entrypoint /\$$defs/PositiveInt --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_entrypoint_pointer.clitest
+++ b/test/validate/pass_entrypoint_pointer.clitest
@@ -20,8 +20,8 @@ RUN validate schema.json instance.json --entrypoint /\$$defs/PositiveInt --verbo
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_entrypoint_pointer_fragment.clitest
+++ b/test/validate/pass_entrypoint_pointer_fragment.clitest
@@ -17,8 +17,6 @@ EOF
 
 RUN validate schema.json instance.json --entrypoint #/\$$defs/PositiveInt --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_entrypoint_pointer_fragment.clitest
+++ b/test/validate/pass_entrypoint_pointer_fragment.clitest
@@ -20,8 +20,8 @@ RUN validate schema.json instance.json --entrypoint #/\$$defs/PositiveInt --verb
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_entrypoint_pointer_fragment_space.clitest
+++ b/test/validate/pass_entrypoint_pointer_fragment_space.clitest
@@ -20,8 +20,8 @@ RUN validate schema.json instance.json --entrypoint '#/$$defs/Positive Int' --ve
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_entrypoint_pointer_fragment_space.clitest
+++ b/test/validate/pass_entrypoint_pointer_fragment_space.clitest
@@ -17,8 +17,6 @@ EOF
 
 RUN validate schema.json instance.json --entrypoint '#/$$defs/Positive Int' --verbose STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_entrypoint_pointer_space.clitest
+++ b/test/validate/pass_entrypoint_pointer_space.clitest
@@ -17,8 +17,6 @@ EOF
 
 RUN validate schema.json instance.json --entrypoint '/$$defs/Positive Int' --verbose STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_entrypoint_pointer_space.clitest
+++ b/test/validate/pass_entrypoint_pointer_space.clitest
@@ -20,8 +20,8 @@ RUN validate schema.json instance.json --entrypoint '/$$defs/Positive Int' --ver
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_entrypoint_uri.clitest
+++ b/test/validate/pass_entrypoint_uri.clitest
@@ -21,8 +21,8 @@ RUN validate schema.json instance.json --entrypoint https://example.com/schema#/
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_entrypoint_uri.clitest
+++ b/test/validate/pass_entrypoint_uri.clitest
@@ -18,8 +18,6 @@ EOF
 
 RUN validate schema.json instance.json --entrypoint https://example.com/schema#/\$$defs/PositiveInt --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_extension_empty_json.clitest
+++ b/test/validate/pass_extension_empty_json.clitest
@@ -26,8 +26,6 @@ EOF
 
 RUN validate schema.json instances --extension '' --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> warning: Matching files with no extension
 2> ok: instances/instance1

--- a/test/validate/pass_extension_empty_json.clitest
+++ b/test/validate/pass_extension_empty_json.clitest
@@ -30,10 +30,10 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> warning: Matching files with no extension
-2> ok: [CWD]/instances/instance1
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instances/instance2
-2>   matches [CWD]/schema.json
+2> ok: instances/instance1
+2>   matches schema.json
+2> ok: instances/instance2
+2>   matches schema.json
 2>
 2> 2 validated, 2 passed, 0 failed
 EOF

--- a/test/validate/pass_extension_empty_yaml.clitest
+++ b/test/validate/pass_extension_empty_yaml.clitest
@@ -26,8 +26,6 @@ EOF
 
 RUN validate schema.json instances --extension '' --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> warning: Matching files with no extension
 2> ok: instances/instance1

--- a/test/validate/pass_extension_empty_yaml.clitest
+++ b/test/validate/pass_extension_empty_yaml.clitest
@@ -30,10 +30,10 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> warning: Matching files with no extension
-2> ok: [CWD]/instances/instance1
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instances/instance2
-2>   matches [CWD]/schema.json
+2> ok: instances/instance1
+2>   matches schema.json
+2> ok: instances/instance2
+2>   matches schema.json
 2>
 2> 2 validated, 2 passed, 0 failed
 EOF

--- a/test/validate/pass_json_no_identifier.clitest
+++ b/test/validate/pass_json_no_identifier.clitest
@@ -18,8 +18,6 @@ EOF
 RUN validate schema.json instance.json --json STDIN /dev/null IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> {
 1>   "valid": true,

--- a/test/validate/pass_jsonl_gz.clitest
+++ b/test/validate/pass_jsonl_gz.clitest
@@ -21,8 +21,6 @@ COMPRESS GZIP instance.jsonl INTO instance.jsonl.gz
 
 RUN validate schema.json instance.jsonl.gz STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> 3 validated, 3 passed, 0 failed
 EOF

--- a/test/validate/pass_jsonl_gz_json.clitest
+++ b/test/validate/pass_jsonl_gz_json.clitest
@@ -21,8 +21,6 @@ COMPRESS GZIP instance.jsonl INTO instance.jsonl.gz
 
 RUN validate schema.json instance.jsonl.gz --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> {
 1>   "valid": true

--- a/test/validate/pass_jsonl_gz_verbose.clitest
+++ b/test/validate/pass_jsonl_gz_verbose.clitest
@@ -25,12 +25,12 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as GZIP-compressed JSONL: [CWD]/instance.jsonl.gz
-2> ok: [CWD]/instance.jsonl.gz (entry #1)
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instance.jsonl.gz (entry #2)
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instance.jsonl.gz (entry #3)
-2>   matches [CWD]/schema.json
+2> ok: instance.jsonl.gz (entry #1)
+2>   matches schema.json
+2> ok: instance.jsonl.gz (entry #2)
+2>   matches schema.json
+2> ok: instance.jsonl.gz (entry #3)
+2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF

--- a/test/validate/pass_jsonl_verbose.clitest
+++ b/test/validate/pass_jsonl_verbose.clitest
@@ -23,12 +23,12 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as JSONL: [CWD]/instance.jsonl
-2> ok: [CWD]/instance.jsonl (entry #1)
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instance.jsonl (entry #2)
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instance.jsonl (entry #3)
-2>   matches [CWD]/schema.json
+2> ok: instance.jsonl (entry #1)
+2>   matches schema.json
+2> ok: instance.jsonl (entry #2)
+2>   matches schema.json
+2> ok: instance.jsonl (entry #3)
+2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF

--- a/test/validate/pass_many_one_empty_directory.clitest
+++ b/test/validate/pass_many_one_empty_directory.clitest
@@ -23,8 +23,8 @@ RUN validate schema.json instances extras --verbose STDIN /dev/null IN . INTO re
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instances/instance_1.json
-2>   matches [CWD]/schema.json
+2> ok: instances/instance_1.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_many_one_empty_directory.clitest
+++ b/test/validate/pass_many_one_empty_directory.clitest
@@ -20,8 +20,6 @@ EOF
 
 RUN validate schema.json instances extras --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instances/instance_1.json
 2>   matches schema.json

--- a/test/validate/pass_many_verbose.clitest
+++ b/test/validate/pass_many_verbose.clitest
@@ -28,12 +28,12 @@ RUN validate schema.json instance_1.json instance_2.json instance_3.json --verbo
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance_1.json
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instance_2.json
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instance_3.json
-2>   matches [CWD]/schema.json
+2> ok: instance_1.json
+2>   matches schema.json
+2> ok: instance_2.json
+2>   matches schema.json
+2> ok: instance_3.json
+2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF

--- a/test/validate/pass_many_verbose.clitest
+++ b/test/validate/pass_many_verbose.clitest
@@ -25,8 +25,6 @@ EOF
 
 RUN validate schema.json instance_1.json instance_2.json instance_3.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance_1.json
 2>   matches schema.json

--- a/test/validate/pass_no_identifier_ref_without_resolve.clitest
+++ b/test/validate/pass_no_identifier_ref_without_resolve.clitest
@@ -27,8 +27,8 @@ RUN validate schema.json instance.json --verbose STDIN /dev/null IN . INTO resul
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_no_identifier_ref_without_resolve.clitest
+++ b/test/validate/pass_no_identifier_ref_without_resolve.clitest
@@ -24,8 +24,6 @@ EOF
 
 RUN validate schema.json instance.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_resolve_custom_metaschema_chain.clitest
+++ b/test/validate/pass_resolve_custom_metaschema_chain.clitest
@@ -68,8 +68,8 @@ RUN validate schema.json instance.json --resolve leaf.json --resolve meta-c.json
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_custom_metaschema_chain.clitest
+++ b/test/validate/pass_resolve_custom_metaschema_chain.clitest
@@ -65,8 +65,6 @@ EOF
 
 RUN validate schema.json instance.json --resolve leaf.json --resolve meta-c.json --resolve meta-b.json --resolve meta-a.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_resolve_custom_metaschema_ordering.clitest
+++ b/test/validate/pass_resolve_custom_metaschema_ordering.clitest
@@ -41,8 +41,8 @@ WRITE expected_0.txt UNTIL EOF
 2> debug: Detecting schema resources from file: [CWD]/aa-schema.json
 2> debug: Importing schema into the resolution context: [CWD_URI]/aa-schema.json
 2> debug: Importing schema into the resolution context: https://example.com/my-schema
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_custom_metaschema_ordering_reversed.clitest
+++ b/test/validate/pass_resolve_custom_metaschema_ordering_reversed.clitest
@@ -59,8 +59,8 @@ RUN validate schema.json instance.json --resolve aa-schema.json --resolve zz-met
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_custom_metaschema_ordering_reversed.clitest
+++ b/test/validate/pass_resolve_custom_metaschema_ordering_reversed.clitest
@@ -56,8 +56,6 @@ EOF
 
 RUN validate schema.json instance.json --resolve aa-schema.json --resolve zz-meta.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_resolve_debug.clitest
+++ b/test/validate/pass_resolve_debug.clitest
@@ -66,8 +66,8 @@ WRITE expected_0.txt UNTIL EOF
 2> debug: Detecting schema resources from file: [CWD]/schemas/nested/bar.json
 2> debug: Importing schema into the resolution context: [CWD_URI]/schemas/nested/bar.json
 2> debug: Importing schema into the resolution context: https://example.com/bar
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_directory_metaschema_ordering.clitest
+++ b/test/validate/pass_resolve_directory_metaschema_ordering.clitest
@@ -68,8 +68,6 @@ EOF
 
 RUN validate schema.json instance.json --resolve good --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json
@@ -80,8 +78,6 @@ EOF
 COMPARE result_0.txt AGAINST expected_0.txt
 
 RUN validate schema.json instance.json --resolve bad --verbose STDIN /dev/null IN . INTO result_1.txt EXPECTING 0
-
-REPLACE $CWD WITH '[CWD]' IN result_1.txt
 
 WRITE expected_1.txt UNTIL EOF
 2> ok: instance.json

--- a/test/validate/pass_resolve_directory_metaschema_ordering.clitest
+++ b/test/validate/pass_resolve_directory_metaschema_ordering.clitest
@@ -71,8 +71,8 @@ RUN validate schema.json instance.json --resolve good --verbose STDIN /dev/null 
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF
@@ -84,8 +84,8 @@ RUN validate schema.json instance.json --resolve bad --verbose STDIN /dev/null I
 REPLACE $CWD WITH '[CWD]' IN result_1.txt
 
 WRITE expected_1.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_duplicate_identifier_identical.clitest
+++ b/test/validate/pass_resolve_duplicate_identifier_identical.clitest
@@ -36,8 +36,6 @@ EOF
 
 RUN validate schema.json instance.json --resolve schemas --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_resolve_duplicate_identifier_identical.clitest
+++ b/test/validate/pass_resolve_duplicate_identifier_identical.clitest
@@ -39,8 +39,8 @@ RUN validate schema.json instance.json --resolve schemas --verbose STDIN /dev/nu
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_remap.clitest
+++ b/test/validate/pass_resolve_remap.clitest
@@ -38,8 +38,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml
 2> Using extension: .yml
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_remap.clitest
+++ b/test/validate/pass_resolve_remap.clitest
@@ -32,8 +32,6 @@ EOF
 
 RUN validate $CWD/schema.json $CWD/instance.json --resolve $CWD/remote.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml

--- a/test/validate/pass_resolve_remap_relative.clitest
+++ b/test/validate/pass_resolve_remap_relative.clitest
@@ -38,8 +38,8 @@ WRITE expected_0.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml
 2> Using extension: .yml
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_remap_relative.clitest
+++ b/test/validate/pass_resolve_remap_relative.clitest
@@ -32,8 +32,6 @@ EOF
 
 RUN validate schema.json instance.json --resolve remote.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> Using extension: .json
 2> Using extension: .yaml

--- a/test/validate/pass_resolve_verbose.clitest
+++ b/test/validate/pass_resolve_verbose.clitest
@@ -53,8 +53,6 @@ EOF
 
 RUN validate schema.json instance.json --resolve foo.json --resolve schemas --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_resolve_verbose.clitest
+++ b/test/validate/pass_resolve_verbose.clitest
@@ -56,8 +56,8 @@ RUN validate schema.json instance.json --resolve foo.json --resolve schemas --ve
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_without_identifier.clitest
+++ b/test/validate/pass_resolve_without_identifier.clitest
@@ -20,8 +20,6 @@ EOF
 
 RUN validate schema.json instance.json --resolve no-id.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_resolve_without_identifier.clitest
+++ b/test/validate/pass_resolve_without_identifier.clitest
@@ -23,8 +23,8 @@ RUN validate schema.json instance.json --resolve no-id.json --verbose STDIN /dev
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_stdin_instance_trace.clitest
+++ b/test/validate/pass_stdin_instance_trace.clitest
@@ -12,8 +12,6 @@ EOF
 RUN validate schema.json - --trace STDIN stdin_0 IN . INTO result.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result.txt
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 1> -> (push) "/type" (AssertionTypeStrict)
 1>    at instance location "" (line 1, column 1)

--- a/test/validate/pass_stdin_instance_verbose.clitest
+++ b/test/validate/pass_stdin_instance_verbose.clitest
@@ -17,8 +17,6 @@ EOF
 
 RUN validate schema.json - --verbose STDIN stdin_input IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: tag:sourcemeta.com,2026:jsonschema/stdin
 2>   matches schema.json

--- a/test/validate/pass_stdin_instance_verbose.clitest
+++ b/test/validate/pass_stdin_instance_verbose.clitest
@@ -21,7 +21,7 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: tag:sourcemeta.com,2026:jsonschema/stdin
-2>   matches [CWD]/schema.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_stdin_mixed_ordering.clitest
+++ b/test/validate/pass_stdin_mixed_ordering.clitest
@@ -22,12 +22,12 @@ RUN validate schema.json instance1.json - instance2.json --verbose STDIN stdin_i
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance1.json
-2>   matches [CWD]/schema.json
+2> ok: instance1.json
+2>   matches schema.json
 2> ok: tag:sourcemeta.com,2026:jsonschema/stdin
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instance2.json
-2>   matches [CWD]/schema.json
+2>   matches schema.json
+2> ok: instance2.json
+2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF

--- a/test/validate/pass_stdin_mixed_ordering.clitest
+++ b/test/validate/pass_stdin_mixed_ordering.clitest
@@ -19,8 +19,6 @@ EOF
 
 RUN validate schema.json instance1.json - instance2.json --verbose STDIN stdin_input IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance1.json
 2>   matches schema.json

--- a/test/validate/pass_stdin_resolve.clitest
+++ b/test/validate/pass_stdin_resolve.clitest
@@ -20,7 +20,7 @@ RUN validate - instance.json --resolve defs.json --verbose STDIN stdin_0 IN . IN
 REPLACE $CWD WITH '[CWD]' IN result.txt
 
 WRITE expected.txt UNTIL EOF
-2> ok: [CWD]/instance.json
+2> ok: instance.json
 2>   matches tag:sourcemeta.com,2026:jsonschema/stdin
 2>
 2> 1 validated, 1 passed, 0 failed

--- a/test/validate/pass_stdin_resolve.clitest
+++ b/test/validate/pass_stdin_resolve.clitest
@@ -17,8 +17,6 @@ EOF
 // Schema from stdin referencing a resolved external schema
 RUN validate - instance.json --resolve defs.json --verbose STDIN stdin_0 IN . INTO result.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result.txt
-
 WRITE expected.txt UNTIL EOF
 2> ok: instance.json
 2>   matches tag:sourcemeta.com,2026:jsonschema/stdin

--- a/test/validate/pass_stdin_schema_verbose.clitest
+++ b/test/validate/pass_stdin_schema_verbose.clitest
@@ -17,7 +17,7 @@ RUN validate - instance.json --verbose STDIN stdin_0 IN . INTO result_0.txt EXPE
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
+2> ok: instance.json
 2>   matches tag:sourcemeta.com,2026:jsonschema/stdin
 2>
 2> 1 validated, 1 passed, 0 failed

--- a/test/validate/pass_stdin_schema_verbose.clitest
+++ b/test/validate/pass_stdin_schema_verbose.clitest
@@ -14,8 +14,6 @@ EOF
 
 RUN validate - instance.json --verbose STDIN stdin_0 IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches tag:sourcemeta.com,2026:jsonschema/stdin

--- a/test/validate/pass_trace.clitest
+++ b/test/validate/pass_trace.clitest
@@ -18,8 +18,6 @@ EOF
 RUN validate schema.json instance.json --trace STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> @- (annotation) "/description" (AnnotationEmit)
 1>    value "Test schema"

--- a/test/validate/pass_trace_fast.clitest
+++ b/test/validate/pass_trace_fast.clitest
@@ -18,8 +18,6 @@ EOF
 RUN validate schema.json instance.json --trace --fast STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> -> (push) "/properties/foo/type" (AssertionPropertyTypeStrict)
 1>    at instance location "/foo" (line 1, column 3)

--- a/test/validate/pass_trace_unknown_keyword.clitest
+++ b/test/validate/pass_trace_unknown_keyword.clitest
@@ -19,8 +19,6 @@ EOF
 RUN validate schema.json instance.json --trace STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
 REPLACE $CWD_URI WITH '[CWD_URI]' IN result_0.txt
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 1> @- (annotation) "/description" (AnnotationEmit)
 1>    value "Test schema"

--- a/test/validate/pass_verbose.clitest
+++ b/test/validate/pass_verbose.clitest
@@ -17,8 +17,6 @@ EOF
 
 RUN validate schema.json instance.json --verbose STDIN /dev/null IN . INTO result_0.txt EXPECTING 0
 
-REPLACE $CWD WITH '[CWD]' IN result_0.txt
-
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
 2>   matches schema.json

--- a/test/validate/pass_verbose.clitest
+++ b/test/validate/pass_verbose.clitest
@@ -20,8 +20,8 @@ RUN validate schema.json instance.json --verbose STDIN /dev/null IN . INTO resul
 REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_verbose_with_template.clitest
+++ b/test/validate/pass_verbose_with_template.clitest
@@ -25,8 +25,8 @@ REPLACE $CWD WITH '[CWD]' IN result_1.txt
 
 WRITE expected_1.txt UNTIL EOF
 2> Parsing pre-compiled schema template: [CWD]/template.json
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_with_invalid_template_verbose.clitest
+++ b/test/validate/pass_with_invalid_template_verbose.clitest
@@ -26,8 +26,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Parsing pre-compiled schema template: [CWD]/template.json
 2> warning: Failed to parse pre-compiled schema template. Compiling from scratch
-2> ok: [CWD]/instance.json
-2>   matches [CWD]/schema.json
+2> ok: instance.json
+2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_yaml_multi_verbose.clitest
+++ b/test/validate/pass_yaml_multi_verbose.clitest
@@ -26,12 +26,12 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as YAML multi-document: [CWD]/instance.yaml
-2> ok: [CWD]/instance.yaml (entry #1)
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instance.yaml (entry #2)
-2>   matches [CWD]/schema.json
-2> ok: [CWD]/instance.yaml (entry #3)
-2>   matches [CWD]/schema.json
+2> ok: instance.yaml (entry #1)
+2>   matches schema.json
+2> ok: instance.yaml (entry #2)
+2>   matches schema.json
+2> ok: instance.yaml (entry #3)
+2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

