### PR TITLE
Drop the per instance `matches <schema>` line from `validate`

### DIFF
--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -144,7 +144,6 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
                    const sourcemeta::blaze::Template &schema_template,
                    bool benchmark, std::uint64_t benchmark_loop, bool trace,
                    bool fast_mode, bool json_output, bool continue_on_error,
-                   const std::filesystem::path &schema_display_path,
                    const sourcemeta::core::Options &options,
                    sourcemeta::jsonschema::ValidationSummary &summary) -> bool {
   sourcemeta::blaze::SimpleOutput output{entry.second};
@@ -214,10 +213,7 @@ auto process_entry(const sourcemeta::jsonschema::InputJSON &entry,
       sourcemeta::jsonschema::LOG_VERBOSE(options)
           << " (entry #" << entry.index + 1 << ")";
     }
-    sourcemeta::jsonschema::LOG_VERBOSE(options)
-        << "\n  matches "
-        << sourcemeta::jsonschema::relative_path_string(schema_display_path)
-        << "\n";
+    sourcemeta::jsonschema::LOG_VERBOSE(options) << "\n";
   } else {
     if (continue_on_error && entry.multidocument && summary.failed > 0) {
       std::cerr << "\n";
@@ -270,10 +266,6 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
                                     : std::filesystem::path(schema_path)};
   const auto schema_resolution_base{
       schema_from_stdin ? stdin_path() : std::filesystem::path(schema_path)};
-  const auto schema_display_path{
-      schema_from_stdin
-          ? stdin_path()
-          : sourcemeta::core::weakly_canonical(schema_resolution_base)};
 
   const auto configuration_path{
       find_configuration(options, schema_config_base)};
@@ -386,8 +378,7 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
     for (auto entry{entries.cbegin()}; entry != entries.cend(); ++entry) {
       if (!process_entry(*entry, evaluator, schema_template, benchmark,
                          benchmark_loop, trace, fast_mode, json_output,
-                         continue_on_error, schema_display_path, options,
-                         summary)) {
+                         continue_on_error, options, summary)) {
         summary.stopped = std::next(entry) != entries.cend();
         break;
       }
@@ -426,8 +417,7 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
         for (auto entry{entries.cbegin()}; entry != entries.cend(); ++entry) {
           if (!process_entry(*entry, evaluator, schema_template, benchmark,
                              benchmark_loop, trace, fast_mode, json_output,
-                             continue_on_error, schema_display_path, options,
-                             summary)) {
+                             continue_on_error, options, summary)) {
             summary.stopped = std::next(entry) != entries.cend();
             proceed = false;
             break;
@@ -490,9 +480,7 @@ auto sourcemeta::jsonschema::validate(const sourcemeta::core::Options &options)
           std::cout << "\n";
         } else if (subresult) {
           LOG_VERBOSE(options)
-              << "ok: " << relative_path_string(instance_display_path)
-              << "\n  matches " << relative_path_string(schema_display_path)
-              << "\n";
+              << "ok: " << relative_path_string(instance_display_path) << "\n";
         } else {
           std::cerr << "fail: " << relative_path_string(instance_display_path)
                     << "\n";

--- a/test/ci/pass_validate_fuse.sh
+++ b/test/ci/pass_validate_fuse.sh
@@ -40,7 +40,6 @@ bindfs --no-allow-other "$TMP" "$FUSE_MOUNT"
 
 cat << 'EOF' > "$TMP/expected.txt"
 ok: instance.json
-  matches level1/level2/level3/schema.json
 
 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/fail_directory_continue_verbose.clitest
+++ b/test/validate/fail_directory_continue_verbose.clitest
@@ -35,7 +35,6 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
 2> ok: instances/instance_2.json
-2>   matches schema.json
 2>
 2> 2 validated, 1 passed, 1 failed
 EOF

--- a/test/validate/fail_directory_verbose.clitest
+++ b/test/validate/fail_directory_verbose.clitest
@@ -30,7 +30,6 @@ RUN validate schema.json instances --verbose STDIN /dev/null IN . INTO result_0.
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instances/instance_1.json
-2>   matches schema.json
 2> fail: instances/nested/instance_2.json
 2> error: Schema validation failure
 2>   The value was expected to be of type integer but it was of type string

--- a/test/validate/fail_jsonl_continue_verbose.clitest
+++ b/test/validate/fail_jsonl_continue_verbose.clitest
@@ -21,7 +21,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as JSONL: [CWD]/instance.jsonl
 2> ok: instance.jsonl (entry #1)
-2>   matches schema.json
 2> fail: instance.jsonl (entry #2)
 2>
 2> [

--- a/test/validate/fail_jsonl_gz_one_verbose.clitest
+++ b/test/validate/fail_jsonl_gz_one_verbose.clitest
@@ -23,7 +23,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as GZIP-compressed JSONL: [CWD]/instance.jsonl.gz
 2> ok: instance.jsonl.gz (entry #1)
-2>   matches schema.json
 2> fail: instance.jsonl.gz (entry #2)
 2>
 2> [

--- a/test/validate/fail_jsonl_one_continue_verbose.clitest
+++ b/test/validate/fail_jsonl_one_continue_verbose.clitest
@@ -21,7 +21,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as JSONL: [CWD]/instance.jsonl
 2> ok: instance.jsonl (entry #1)
-2>   matches schema.json
 2> fail: instance.jsonl (entry #2)
 2>
 2> [
@@ -36,7 +35,6 @@ WRITE expected_0.txt UNTIL EOF
 2>     at evaluate path "/type"
 2>
 2> ok: instance.jsonl (entry #3)
-2>   matches schema.json
 2>
 2> 3 validated, 2 passed, 1 failed
 EOF

--- a/test/validate/fail_jsonl_one_verbose.clitest
+++ b/test/validate/fail_jsonl_one_verbose.clitest
@@ -21,7 +21,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as JSONL: [CWD]/instance.jsonl
 2> ok: instance.jsonl (entry #1)
-2>   matches schema.json
 2> fail: instance.jsonl (entry #2)
 2>
 2> [

--- a/test/validate/fail_many_continue_verbose.clitest
+++ b/test/validate/fail_many_continue_verbose.clitest
@@ -29,7 +29,6 @@ RUN validate schema.json instance_1.json instance_2.json instance_3.json --conti
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance_1.json
-2>   matches schema.json
 2> fail: instance_2.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer
@@ -39,7 +38,6 @@ WRITE expected_0.txt UNTIL EOF
 2>     at instance location "" (line 1, column 1)
 2>     at evaluate path "/properties"
 2> ok: instance_3.json
-2>   matches schema.json
 2>
 2> 3 validated, 2 passed, 1 failed
 EOF

--- a/test/validate/fail_many_verbose.clitest
+++ b/test/validate/fail_many_verbose.clitest
@@ -29,7 +29,6 @@ RUN validate schema.json instance_1.json instance_2.json instance_3.json --verbo
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance_1.json
-2>   matches schema.json
 2> fail: instance_2.json
 2> error: Schema validation failure
 2>   The value was expected to be of type string but it was of type integer

--- a/test/validate/fail_yaml_multi_blank_lines.clitest
+++ b/test/validate/fail_yaml_multi_blank_lines.clitest
@@ -26,7 +26,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as YAML multi-document: [CWD]/instance.yaml
 2> ok: instance.yaml (entry #1)
-2>   matches schema.json
 2> fail: instance.yaml (entry #2)
 2>
 2> [

--- a/test/validate/fail_yaml_multi_one_verbose.clitest
+++ b/test/validate/fail_yaml_multi_one_verbose.clitest
@@ -24,7 +24,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as YAML multi-document: [CWD]/instance.yaml
 2> ok: instance.yaml (entry #1)
-2>   matches schema.json
 2> fail: instance.yaml (entry #2)
 2>
 2> [

--- a/test/validate/pass_2020_12_default_dialect_config.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config.clitest
@@ -22,7 +22,6 @@ RUN validate --verbose $CWD/schema.json $CWD/instance.json STDIN /dev/null IN . 
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_2020_12_default_dialect_config_parent.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config_parent.clitest
@@ -24,7 +24,6 @@ RUN validate --verbose level1/level2/level3/schema.json instance.json STDIN /dev
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches level1/level2/level3/schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_2020_12_default_dialect_config_relative.clitest
+++ b/test/validate/pass_2020_12_default_dialect_config_relative.clitest
@@ -22,7 +22,6 @@ RUN validate --verbose schema.json instance.json STDIN /dev/null IN . INTO resul
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_2020_12_format_assertion.clitest
+++ b/test/validate/pass_2020_12_format_assertion.clitest
@@ -32,7 +32,6 @@ RUN validate schema.json instance.json --resolve metaschema.json --verbose STDIN
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_2020_12_format_assertion_optional.clitest
+++ b/test/validate/pass_2020_12_format_assertion_optional.clitest
@@ -32,7 +32,6 @@ RUN validate schema.json instance.json --resolve metaschema.json --verbose STDIN
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_config_ignore_with_cli.clitest
+++ b/test/validate/pass_config_ignore_with_cli.clitest
@@ -49,7 +49,6 @@ WRITE expected_0.txt UNTIL EOF
 2> Using extension: .yaml
 2> Using extension: .yml
 2> ok: instances/valid.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_configuration_option.clitest
+++ b/test/validate/pass_configuration_option.clitest
@@ -27,7 +27,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_configuration_option_custom_name.clitest
+++ b/test/validate/pass_configuration_option_custom_name.clitest
@@ -25,7 +25,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/jsonschema.ci.json
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_configuration_option_directory.clitest
+++ b/test/validate/pass_configuration_option_directory.clitest
@@ -27,7 +27,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_configuration_option_over_discovered.clitest
+++ b/test/validate/pass_configuration_option_over_discovered.clitest
@@ -33,7 +33,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_configuration_option_short.clitest
+++ b/test/validate/pass_configuration_option_short.clitest
@@ -27,7 +27,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Using configuration file: [CWD]/config/jsonschema.json
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_cwd.clitest
+++ b/test/validate/pass_cwd.clitest
@@ -27,11 +27,8 @@ REPLACE $CWD WITH '[CWD]' IN result.txt
 WRITE expected.txt UNTIL EOF
 2> warning: Recursively processing every file in [CWD] as no input was provided
 2> ok: instance_1.json
-2>   matches schema.json
 2> ok: instance_2.json
-2>   matches schema.json
 2> ok: schema.json
-2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF

--- a/test/validate/pass_cwd_config_no_path.clitest
+++ b/test/validate/pass_cwd_config_no_path.clitest
@@ -36,9 +36,7 @@ WRITE expected.txt UNTIL EOF
 2> Using extension: .yaml
 2> Using extension: .yml
 2> ok: instance.json
-2>   matches schema.json
 2> ok: schema.json
-2>   matches schema.json
 2>
 2> 2 validated, 2 passed, 0 failed
 EOF

--- a/test/validate/pass_default_dialect_cli_relative.clitest
+++ b/test/validate/pass_default_dialect_cli_relative.clitest
@@ -26,7 +26,6 @@ RUN validate schema.json instance.json --default-dialect ../meta.json --verbose 
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_directory_extension_verbose.clitest
+++ b/test/validate/pass_directory_extension_verbose.clitest
@@ -30,9 +30,7 @@ RUN validate schema.json instances --extension .data.json --verbose STDIN /dev/n
 WRITE expected_0.txt UNTIL EOF
 2> Using extension: .data.json
 2> ok: instances/instance_1.data.json
-2>   matches schema.json
 2> ok: instances/instance_2.data.json
-2>   matches schema.json
 2>
 2> 2 validated, 2 passed, 0 failed
 EOF

--- a/test/validate/pass_directory_ignore_verbose.clitest
+++ b/test/validate/pass_directory_ignore_verbose.clitest
@@ -28,7 +28,6 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Ignoring path: "[CWD]/instances/drafts"
 2> ok: instances/instance_1.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_directory_verbose.clitest
+++ b/test/validate/pass_directory_verbose.clitest
@@ -28,9 +28,7 @@ RUN validate schema.json instances --verbose STDIN /dev/null IN . INTO result_0.
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instances/instance_1.json
-2>   matches schema.json
 2> ok: instances/instance_2.json
-2>   matches schema.json
 2>
 2> 2 validated, 2 passed, 0 failed
 EOF

--- a/test/validate/pass_entrypoint_pointer.clitest
+++ b/test/validate/pass_entrypoint_pointer.clitest
@@ -19,7 +19,6 @@ RUN validate schema.json instance.json --entrypoint /\$$defs/PositiveInt --verbo
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_entrypoint_pointer_fragment.clitest
+++ b/test/validate/pass_entrypoint_pointer_fragment.clitest
@@ -19,7 +19,6 @@ RUN validate schema.json instance.json --entrypoint #/\$$defs/PositiveInt --verb
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_entrypoint_pointer_fragment_space.clitest
+++ b/test/validate/pass_entrypoint_pointer_fragment_space.clitest
@@ -19,7 +19,6 @@ RUN validate schema.json instance.json --entrypoint '#/$$defs/Positive Int' --ve
 
 WRITE expected.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_entrypoint_pointer_space.clitest
+++ b/test/validate/pass_entrypoint_pointer_space.clitest
@@ -19,7 +19,6 @@ RUN validate schema.json instance.json --entrypoint '/$$defs/Positive Int' --ver
 
 WRITE expected.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_entrypoint_uri.clitest
+++ b/test/validate/pass_entrypoint_uri.clitest
@@ -20,7 +20,6 @@ RUN validate schema.json instance.json --entrypoint https://example.com/schema#/
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_extension_empty_json.clitest
+++ b/test/validate/pass_extension_empty_json.clitest
@@ -29,9 +29,7 @@ RUN validate schema.json instances --extension '' --verbose STDIN /dev/null IN .
 WRITE expected_0.txt UNTIL EOF
 2> warning: Matching files with no extension
 2> ok: instances/instance1
-2>   matches schema.json
 2> ok: instances/instance2
-2>   matches schema.json
 2>
 2> 2 validated, 2 passed, 0 failed
 EOF

--- a/test/validate/pass_extension_empty_yaml.clitest
+++ b/test/validate/pass_extension_empty_yaml.clitest
@@ -29,9 +29,7 @@ RUN validate schema.json instances --extension '' --verbose STDIN /dev/null IN .
 WRITE expected_0.txt UNTIL EOF
 2> warning: Matching files with no extension
 2> ok: instances/instance1
-2>   matches schema.json
 2> ok: instances/instance2
-2>   matches schema.json
 2>
 2> 2 validated, 2 passed, 0 failed
 EOF

--- a/test/validate/pass_jsonl_gz_verbose.clitest
+++ b/test/validate/pass_jsonl_gz_verbose.clitest
@@ -26,11 +26,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as GZIP-compressed JSONL: [CWD]/instance.jsonl.gz
 2> ok: instance.jsonl.gz (entry #1)
-2>   matches schema.json
 2> ok: instance.jsonl.gz (entry #2)
-2>   matches schema.json
 2> ok: instance.jsonl.gz (entry #3)
-2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF

--- a/test/validate/pass_jsonl_verbose.clitest
+++ b/test/validate/pass_jsonl_verbose.clitest
@@ -24,11 +24,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as JSONL: [CWD]/instance.jsonl
 2> ok: instance.jsonl (entry #1)
-2>   matches schema.json
 2> ok: instance.jsonl (entry #2)
-2>   matches schema.json
 2> ok: instance.jsonl (entry #3)
-2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF

--- a/test/validate/pass_many_one_empty_directory.clitest
+++ b/test/validate/pass_many_one_empty_directory.clitest
@@ -22,7 +22,6 @@ RUN validate schema.json instances extras --verbose STDIN /dev/null IN . INTO re
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instances/instance_1.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_many_verbose.clitest
+++ b/test/validate/pass_many_verbose.clitest
@@ -27,11 +27,8 @@ RUN validate schema.json instance_1.json instance_2.json instance_3.json --verbo
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance_1.json
-2>   matches schema.json
 2> ok: instance_2.json
-2>   matches schema.json
 2> ok: instance_3.json
-2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF

--- a/test/validate/pass_no_identifier_ref_without_resolve.clitest
+++ b/test/validate/pass_no_identifier_ref_without_resolve.clitest
@@ -26,7 +26,6 @@ RUN validate schema.json instance.json --verbose STDIN /dev/null IN . INTO resul
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_custom_metaschema_chain.clitest
+++ b/test/validate/pass_resolve_custom_metaschema_chain.clitest
@@ -67,7 +67,6 @@ RUN validate schema.json instance.json --resolve leaf.json --resolve meta-c.json
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_custom_metaschema_ordering.clitest
+++ b/test/validate/pass_resolve_custom_metaschema_ordering.clitest
@@ -42,7 +42,6 @@ WRITE expected_0.txt UNTIL EOF
 2> debug: Importing schema into the resolution context: [CWD_URI]/aa-schema.json
 2> debug: Importing schema into the resolution context: https://example.com/my-schema
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_custom_metaschema_ordering_reversed.clitest
+++ b/test/validate/pass_resolve_custom_metaschema_ordering_reversed.clitest
@@ -58,7 +58,6 @@ RUN validate schema.json instance.json --resolve aa-schema.json --resolve zz-met
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_debug.clitest
+++ b/test/validate/pass_resolve_debug.clitest
@@ -67,7 +67,6 @@ WRITE expected_0.txt UNTIL EOF
 2> debug: Importing schema into the resolution context: [CWD_URI]/schemas/nested/bar.json
 2> debug: Importing schema into the resolution context: https://example.com/bar
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_directory_metaschema_ordering.clitest
+++ b/test/validate/pass_resolve_directory_metaschema_ordering.clitest
@@ -70,7 +70,6 @@ RUN validate schema.json instance.json --resolve good --verbose STDIN /dev/null 
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF
@@ -81,7 +80,6 @@ RUN validate schema.json instance.json --resolve bad --verbose STDIN /dev/null I
 
 WRITE expected_1.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_duplicate_identifier_identical.clitest
+++ b/test/validate/pass_resolve_duplicate_identifier_identical.clitest
@@ -38,7 +38,6 @@ RUN validate schema.json instance.json --resolve schemas --verbose STDIN /dev/nu
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_remap.clitest
+++ b/test/validate/pass_resolve_remap.clitest
@@ -37,7 +37,6 @@ WRITE expected_0.txt UNTIL EOF
 2> Using extension: .yaml
 2> Using extension: .yml
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_remap_relative.clitest
+++ b/test/validate/pass_resolve_remap_relative.clitest
@@ -37,7 +37,6 @@ WRITE expected_0.txt UNTIL EOF
 2> Using extension: .yaml
 2> Using extension: .yml
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_verbose.clitest
+++ b/test/validate/pass_resolve_verbose.clitest
@@ -55,7 +55,6 @@ RUN validate schema.json instance.json --resolve foo.json --resolve schemas --ve
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_resolve_without_identifier.clitest
+++ b/test/validate/pass_resolve_without_identifier.clitest
@@ -22,7 +22,6 @@ RUN validate schema.json instance.json --resolve no-id.json --verbose STDIN /dev
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_stdin_instance_verbose.clitest
+++ b/test/validate/pass_stdin_instance_verbose.clitest
@@ -19,7 +19,6 @@ RUN validate schema.json - --verbose STDIN stdin_input IN . INTO result_0.txt EX
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: tag:sourcemeta.com,2026:jsonschema/stdin
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_stdin_mixed_ordering.clitest
+++ b/test/validate/pass_stdin_mixed_ordering.clitest
@@ -21,11 +21,8 @@ RUN validate schema.json instance1.json - instance2.json --verbose STDIN stdin_i
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance1.json
-2>   matches schema.json
 2> ok: tag:sourcemeta.com,2026:jsonschema/stdin
-2>   matches schema.json
 2> ok: instance2.json
-2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF

--- a/test/validate/pass_stdin_resolve.clitest
+++ b/test/validate/pass_stdin_resolve.clitest
@@ -19,7 +19,6 @@ RUN validate - instance.json --resolve defs.json --verbose STDIN stdin_0 IN . IN
 
 WRITE expected.txt UNTIL EOF
 2> ok: instance.json
-2>   matches tag:sourcemeta.com,2026:jsonschema/stdin
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_stdin_schema_verbose.clitest
+++ b/test/validate/pass_stdin_schema_verbose.clitest
@@ -16,7 +16,6 @@ RUN validate - instance.json --verbose STDIN stdin_0 IN . INTO result_0.txt EXPE
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches tag:sourcemeta.com,2026:jsonschema/stdin
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_verbose.clitest
+++ b/test/validate/pass_verbose.clitest
@@ -19,7 +19,6 @@ RUN validate schema.json instance.json --verbose STDIN /dev/null IN . INTO resul
 
 WRITE expected_0.txt UNTIL EOF
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_verbose_with_template.clitest
+++ b/test/validate/pass_verbose_with_template.clitest
@@ -26,7 +26,6 @@ REPLACE $CWD WITH '[CWD]' IN result_1.txt
 WRITE expected_1.txt UNTIL EOF
 2> Parsing pre-compiled schema template: [CWD]/template.json
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_with_invalid_template_verbose.clitest
+++ b/test/validate/pass_with_invalid_template_verbose.clitest
@@ -27,7 +27,6 @@ WRITE expected_0.txt UNTIL EOF
 2> Parsing pre-compiled schema template: [CWD]/template.json
 2> warning: Failed to parse pre-compiled schema template. Compiling from scratch
 2> ok: instance.json
-2>   matches schema.json
 2>
 2> 1 validated, 1 passed, 0 failed
 EOF

--- a/test/validate/pass_yaml_multi_verbose.clitest
+++ b/test/validate/pass_yaml_multi_verbose.clitest
@@ -27,11 +27,8 @@ REPLACE $CWD WITH '[CWD]' IN result_0.txt
 WRITE expected_0.txt UNTIL EOF
 2> Interpreting input as YAML multi-document: [CWD]/instance.yaml
 2> ok: instance.yaml (entry #1)
-2>   matches schema.json
 2> ok: instance.yaml (entry #2)
-2>   matches schema.json
 2> ok: instance.yaml (entry #3)
-2>   matches schema.json
 2>
 2> 3 validated, 3 passed, 0 failed
 EOF


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

