### PR TITLE
Support --trace/-t in the test command

### DIFF
--- a/src/command_test.cc
+++ b/src/command_test.cc
@@ -208,6 +208,7 @@ auto run_suite_as_text(const sourcemeta::core::Options &options,
         sourcemeta::jsonschema::default_dialect(options, configuration)};
     const auto &schema_resolver{sourcemeta::jsonschema::resolver(
         options, options.contains("http"), dialect, configuration)};
+    const auto trace{options.contains("trace")};
 
     auto test_suite{parse_test_suite(
         entry, schema_resolver, dialect,
@@ -273,6 +274,17 @@ auto run_suite_as_text(const sourcemeta::core::Options &options,
             stream << entry_indent << index << "/" << total << " FAIL "
                    << description << "\n\n";
             sourcemeta::jsonschema::print(output, test_case.tracker, stream);
+
+            if (trace) {
+              stream << "\n";
+              sourcemeta::blaze::TraceOutput trace_output{
+                  test_suite.exhaustive(target_index),
+                  sourcemeta::jsonschema::trace_callback(test_case.tracker,
+                                                         stream)};
+              test_suite.evaluator.validate(test_suite.exhaustive(target_index),
+                                            test_case.data,
+                                            std::ref(trace_output));
+            }
 
             if (index != total && verbose) {
               stream << "\n";
@@ -629,6 +641,11 @@ auto report_as_ctrf(const sourcemeta::core::Options &options,
 auto sourcemeta::jsonschema::test(const sourcemeta::core::Options &options)
     -> void {
   validate_http_headers(options);
+  if (options.contains("trace") && options.contains("json")) {
+    throw OptionConflictError{
+        "The `--trace/-t` and `--json/-j` options are mutually exclusive"};
+  }
+
   const auto jobs{parse_jobs(options)};
   LOG_VERBOSE(options) << "Using parallelism: " << jobs << "\n";
   if (options.contains("json")) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -80,10 +80,11 @@ Commands:
 
    test [schemas-or-directories...] [--extension/-e <extension>]
         [--ignore/-i <schemas-or-directories>] [--format-assertion/-F]
-        [--jobs/-J <count>]
+        [--jobs/-J <count>] [--trace/-t]
 
        Run a set of unit tests against a schema.
        Pass --json/-j to output results in CTRF format (https://ctrf.io).
+       Pass --trace/-t to print the evaluation trace of every failing test.
 
    fmt [schemas-or-directories...] [--check/-c] [--extension/-e <extension>]
        [--ignore/-i <schemas-or-directories>] [--keep-ordering/-k]
@@ -252,6 +253,7 @@ auto jsonschema_main(const std::string &program, const std::string &command,
 
   if (command == "test") {
     app.flag("format-assertion", {"F"});
+    app.flag("trace", {"t"});
     app.option("extension", {"e"});
     app.option("ignore", {"i"});
     app.option("jobs", {"J"});

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -585,6 +585,8 @@ add_jsonschema_test(test/fail_tests_empty_jobs_json)
 add_jsonschema_test(test/fail_multi_jobs_parse_error_json)
 add_jsonschema_test(test/pass_jobs_verbose)
 add_jsonschema_test(test/pass_bundled_metaschema)
+add_jsonschema_test(test/fail_trace)
+add_jsonschema_test(test/fail_trace_json)
 
 # Bundle
 add_jsonschema_test(bundle/pass_into_resolve_directory)

--- a/test/help_command.clitest
+++ b/test/help_command.clitest
@@ -73,10 +73,11 @@ WRITE expected.txt UNTIL EOF
 1>
 1>    test [schemas-or-directories...] [--extension/-e <extension>]
 1>         [--ignore/-i <schemas-or-directories>] [--format-assertion/-F]
-1>         [--jobs/-J <count>]
+1>         [--jobs/-J <count>] [--trace/-t]
 1>
 1>        Run a set of unit tests against a schema.
 1>        Pass --json/-j to output results in CTRF format (https://ctrf.io).
+1>        Pass --trace/-t to print the evaluation trace of every failing test.
 1>
 1>    fmt [schemas-or-directories...] [--check/-c] [--extension/-e <extension>]
 1>        [--ignore/-i <schemas-or-directories>] [--keep-ordering/-k]

--- a/test/help_option_long.clitest
+++ b/test/help_option_long.clitest
@@ -73,10 +73,11 @@ WRITE expected.txt UNTIL EOF
 1>
 1>    test [schemas-or-directories...] [--extension/-e <extension>]
 1>         [--ignore/-i <schemas-or-directories>] [--format-assertion/-F]
-1>         [--jobs/-J <count>]
+1>         [--jobs/-J <count>] [--trace/-t]
 1>
 1>        Run a set of unit tests against a schema.
 1>        Pass --json/-j to output results in CTRF format (https://ctrf.io).
+1>        Pass --trace/-t to print the evaluation trace of every failing test.
 1>
 1>    fmt [schemas-or-directories...] [--check/-c] [--extension/-e <extension>]
 1>        [--ignore/-i <schemas-or-directories>] [--keep-ordering/-k]

--- a/test/help_option_short.clitest
+++ b/test/help_option_short.clitest
@@ -73,10 +73,11 @@ WRITE expected.txt UNTIL EOF
 1>
 1>    test [schemas-or-directories...] [--extension/-e <extension>]
 1>         [--ignore/-i <schemas-or-directories>] [--format-assertion/-F]
-1>         [--jobs/-J <count>]
+1>         [--jobs/-J <count>] [--trace/-t]
 1>
 1>        Run a set of unit tests against a schema.
 1>        Pass --json/-j to output results in CTRF format (https://ctrf.io).
+1>        Pass --trace/-t to print the evaluation trace of every failing test.
 1>
 1>    fmt [schemas-or-directories...] [--check/-c] [--extension/-e <extension>]
 1>        [--ignore/-i <schemas-or-directories>] [--keep-ordering/-k]

--- a/test/test/fail_trace.clitest
+++ b/test/test/fail_trace.clitest
@@ -1,0 +1,57 @@
+WRITE schema.json UNTIL EOF
+{
+  "id": "https://example.com",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "string"
+}
+EOF
+
+WRITE test.json UNTIL EOF
+{
+  "target": "https://example.com",
+  "tests": [
+    {
+      "description": "First test fails",
+      "valid": true,
+      "data": 1
+    }
+  ]
+}
+EOF
+
+// Validation failure
+RUN test test.json --resolve schema.json --trace STDIN /dev/null IN . INTO result_0.txt EXPECTING 2
+
+REPLACE $CWD WITH '[CWD]' IN result_0.txt
+
+WRITE expected_0.txt UNTIL EOF
+1> [CWD]/test.json:
+1>   1/1 FAIL First test fails
+1>
+1> error: Schema validation failure
+1>   The value was expected to be of type string but it was of type integer
+1>     at instance location ""
+1>     at evaluate path "/type"
+1>
+1> -> (push) "/$ref" (ControlJump)
+1>    at instance location ""
+1>    at keyword location "#/$ref"
+1>    at vocabulary "https://json-schema.org/draft/2020-12/vocab/core"
+1>
+1> -> (push) "/$ref/type" (AssertionTypeStrict)
+1>    at instance location ""
+1>    at keyword location "https://example.com#/type"
+1>    at vocabulary "http://json-schema.org/draft-04/schema#"
+1>
+1> <- (fail) "/$ref/type" (AssertionTypeStrict)
+1>    at instance location ""
+1>    at keyword location "https://example.com#/type"
+1>    at vocabulary "http://json-schema.org/draft-04/schema#"
+1>
+1> <- (fail) "/$ref" (ControlJump)
+1>    at instance location ""
+1>    at keyword location "#/$ref"
+1>    at vocabulary "https://json-schema.org/draft/2020-12/vocab/core"
+EOF
+
+COMPARE result_0.txt AGAINST expected_0.txt

--- a/test/test/fail_trace_json.clitest
+++ b/test/test/fail_trace_json.clitest
@@ -1,0 +1,30 @@
+WRITE schema.json UNTIL EOF
+{
+  "id": "https://example.com",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "string"
+}
+EOF
+
+WRITE test.json UNTIL EOF
+{
+  "target": "https://example.com",
+  "tests": [
+    {
+      "valid": true,
+      "data": "foo"
+    }
+  ]
+}
+EOF
+
+// Invalid CLI arguments
+RUN test test.json --resolve schema.json --trace --json STDIN /dev/null IN . INTO result_0.txt EXPECTING 5
+
+WRITE expected_0.txt UNTIL EOF
+1> {
+1>   "error": "The `--trace/-t` and `--json/-j` options are mutually exclusive"
+1> }
+EOF
+
+COMPARE result_0.txt AGAINST expected_0.txt


### PR DESCRIPTION
The `validate` and `metaschema` commands both support `--trace/-t` to print the evaluation trace on failure, but `test` had no equivalent, despite issue #307 asking for exactly this.

This adds a `--trace/-t` flag to the `test` command, wired into the same failure path that already prints the explanation for a failed test case, so a trace is emitted right after it. Passing `--trace` together with `--json` is rejected the same way `validate` already rejects that combination for itself.

Verified by adding two new end to end test cases (`fail_trace`, `fail_trace_json`) that check the actual output of the built binary, and by running the full `test` and `validate` suites locally: 130 and 267 tests respectively, all passing.

Fixes #307


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/jsonschema/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

